### PR TITLE
fix(deploy): Remove the 3rd party action; use Heroku CLI directly

### DIFF
--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -10,11 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: akhileshns/heroku-deploy@v3.12.12 # This is the action
-        with:
-          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
-          heroku_app_name: ${{secrets.HEROKU_APP_NAME}} #Must be unique in Heroku
-          heroku_email: ${{secrets.HEROKU_EMAIL}}
-          branch: main
-          team: "civichacker"
-      - run: git remote -v
+      - name: Login to Heroku Container registry
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: heroku container:login
+      - name: Build and push
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: heroku container:push -a ${{ secrets.HEROKU_APP_NAME }} web
+      - name: Release
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: heroku container:release -a ${{ secrets.HEROKU_APP_NAME }} web


### PR DESCRIPTION
This Pull Request attempts to use the Heroku CLI directly b/c it's comes preinstalled on the Ubuntu 20.04 image.

See: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md

closes #67 