### PR TITLE
Run Flask dev server in docker-compose 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Files that shouldn't be copied into the api image
+frontend
+.vscode
+.pytest_cache
+.env
+**/__pycache__

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.8-slim-buster AS base
 
 RUN apt-get update && apt-get install curl -y
 
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
+RUN chmod +x /wait
+
 FROM base
 WORKDIR /app/
 
@@ -12,4 +15,5 @@ RUN pip3 install -r requirements/dev_unix.txt
 COPY . .
 
 ENV PORT=5000
-CMD ["/bin/bash", "run_prod.sh"]
+
+CMD /wait && ./run_dev.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,11 @@ services:
   web:
     restart: always
     build:
-      context: .
-      dockerfile: ./frontend/Dockerfile
+      context: ./frontend
     volumes:
-      - ./frontend/pages:/usr/src/app/pages
-      - ./frontend/public:/usr/src/app/public
-      - ./frontend/styles:/usr/src/app/styles
+      - ./frontend:/app
+      # Prevents the host node_modules from clobbering the image's
+      - /app/node_modules
     ports:
       - 3000:3000
   api:
@@ -30,6 +29,7 @@ services:
       - db
     environment:
       POSTGRES_HOST: db
+      WAIT_HOSTS: db:5432
     ports:
       - 5000:5000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,13 @@ services:
     build:
       context: .
       dockerfile: ./backend/Dockerfile
+    volumes:
+      - .:/app
     depends_on:
       - db
     environment:
       POSTGRES_HOST: db
+      FLASK_ENV: development
       WAIT_HOSTS: db:5432
     ports:
       - 5000:5000

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+# Files that shouldn't be copied into the web image
+node_modules
+.next

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# Non-UI frontend code
+!lib

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,16 +1,14 @@
 FROM node:lts-buster
 RUN npm install --global npm@latest
 
-WORKDIR /usr/src/app
+WORKDIR /app/
 
 USER root
 
-COPY frontend/package*.json /usr/src/app/
-RUN npm install --no-optional --quiet 1>/dev/null
+COPY package*.json ./
+RUN npm ci --no-optional --quiet 1>/dev/null
 
-COPY .git/hooks/ .git/hooks/
-RUN npm run prepare
-COPY frontend/ ./
+COPY . .
 
 ENV POSTGRES_HOST=$DATABASE
 ENV PORT=3000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:lts-buster
+RUN npm install --global npm@latest
 
 WORKDIR /usr/src/app
 

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export FLASK_ENV=development
+
+flask psql create
+flask psql init
+flask run --host=0.0.0.0


### PR DESCRIPTION
Fixes #118 

Run the flask dev server and table init scripts on startup. Also exclude unnecessary folders from images to reduce size/build time.