### PR TITLE
rename /auth/test to /auth/whoami

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -133,7 +133,7 @@ def logout():
     return resp, 200
 
 
-@bp.route("/test", methods=["GET"])
+@bp.route("/whoami", methods=["GET"])
 @jwt_required()
 @min_role_required(UserRole.PUBLIC)
 @validate()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -72,7 +72,7 @@ def test_auth_test_header(client, example_user):
     client.set_cookie("localhost", "access_token_cookie", value="")
 
     test_res = client.get(
-        "api/v1/auth/test",
+        "api/v1/auth/whoami",
         headers={
             "Authorization": "Bearer {0}".format(login_res.json["access_token"])
         },
@@ -88,7 +88,7 @@ def test_auth_test_cookie(client, example_user):
     )
 
     test_res = client.get(
-        "api/v1/auth/test",
+        "api/v1/auth/whoami",
     )
 
     assert test_res.status_code == 200

--- a/frontend/helpers/api/api.ts
+++ b/frontend/helpers/api/api.ts
@@ -92,7 +92,7 @@ export function register(data: RegisterRequest): Promise<AccessToken> {
 
 export function whoami({ accessToken }: WhoamiRequest): Promise<User> {
   return request({
-    url: "/auth/test",
+    url: "/auth/whoami",
     method: "GET",
     accessToken
   }).then(({ active, email, email_confirmed_at, first_name, last_name, phone_number, role }) => ({

--- a/frontend/helpers/api/mocks/handlers.ts
+++ b/frontend/helpers/api/mocks/handlers.ts
@@ -25,7 +25,7 @@ export const handlers = [
     return res(ctx.status(200), ctx.json({ access_token: token }))
   }),
 
-  rest.get(routePath("/auth/test"), (req, res, ctx) => {
+  rest.get(routePath("/auth/whoami"), (req, res, ctx) => {
     const token = req.headers.get("Authorization")?.match(/^Bearer (?<token>.*)$/)?.groups?.token
     const user = token && auth.whoami(token)
 


### PR DESCRIPTION
Renamed /auth/test route as described in #161 