### PR TITLE
Removes duplicate header component from search page

### DIFF
--- a/frontend/pages/search/index.tsx
+++ b/frontend/pages/search/index.tsx
@@ -9,7 +9,6 @@ export default requireAuth(function Dashboard() {
 
   return (
     <Layout>
-      <DashboardHeader />
       <div className={searchPageContainer}>
         <SearchPanel />
         <div className={searchPageDisplay}>


### PR DESCRIPTION
DashboardHeader component was redundantly rendered inside the search page component.
Closes #258.