### PR TITLE
[Closes #262] Readme Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ POSTGRES_HOST=db
 This method runs the frontend natively on your computer and does not require a running backend, which can be convenient.
 
 1. Make sure that you have `node 16+` and either `npm 7+` or `yarn` installed.
-2. Follow the install instructions in the [frontend](./frontend/README.md) directory.
+2. Follow the [install instructions](./frontend/README.md) in the `frontend` directory.
 
 # Documentation
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,7 @@
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
-*These instructions are for frontend only.  If you are just getting started with the project, or need help starting the Docker environment, see the [README](../README.md) in the root directory.*
+_These instructions are for frontend only. If you are just getting started with the project, or need help starting the Docker environment, see the [README](../README.md) in the root directory._
 
 ## Getting Started
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,4 +1,8 @@
+# Frontend
+
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+
+*These instructions are for frontend only.  If you are just getting started with the project, or need help starting the Docker environment, see the [README](../README.md) in the root directory.*
 
 ## Getting Started
 


### PR DESCRIPTION
- Adds a link in the frontend README, linking back to the parent README in the root directory.
- Clarifies link in parent README referencing the frontend installation instructions.