### PR TITLE
Create Partners Endpoint

### DIFF
--- a/backend/dto/__init__.py
+++ b/backend/dto/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa: F401
 from .user.register_user import RegisterUserDTO
 from .user.login_user import LoginUserDTO
+from .user.invite_user import InviteUserDTO

--- a/backend/dto/user/invite_user.py
+++ b/backend/dto/user/invite_user.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, EmailStr
-from typing import Optional
 from enum import Enum
+
 
 class MemberRole(str, Enum):
     ADMIN = "Administrator"
@@ -12,4 +12,3 @@ class MemberRole(str, Enum):
 class InviteUserDTO(BaseModel):
     email: EmailStr
     role:  MemberRole
-

--- a/backend/dto/user/invite_user.py
+++ b/backend/dto/user/invite_user.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, EmailStr
+from typing import Optional
+from enum import Enum
+
+class MemberRole(str, Enum):
+    ADMIN = "Administrator"
+    PUBLISHER = "Publisher"
+    MEMBER = "Member"
+    SUBSCRIBER = "Subscriber"
+
+
+class InviteUserDTO(BaseModel):
+    email: EmailStr
+    role:  MemberRole
+

--- a/backend/routes/partners.py
+++ b/backend/routes/partners.py
@@ -1,15 +1,10 @@
 from backend.auth.jwt import min_role_required
 from backend.mixpanel.mix import track_to_mp
 from backend.database.models.user import User, UserRole
-from flask import Blueprint, abort, current_app, request,jsonify
+from flask import Blueprint, abort, current_app, request, jsonify
 from flask_jwt_extended import get_jwt
 from flask_jwt_extended.view_decorators import jwt_required
 from ..database import Partner, PartnerMember, MemberRole, db
-from ..dto import InviteUserDTO
-from flask_mail import Message
-
-
-
 
 
 from ..schemas import (
@@ -48,7 +43,14 @@ def create():
     # if current_app.env == "production":
     #     abort(418)
 
-    if body.name is not None and body.url is not None and body.contact_email is not None and body.name!="" and body.url!="" and body.contact_email!="":
+    if (
+        body.name is not None
+        and body.url is not None
+        and body.contact_email is not None
+        and body.name != ""
+        and body.url != ""
+        and body.contact_email != ""
+    ):
 
         """
         check if instance already is in the db
@@ -57,31 +59,31 @@ def create():
             partner = partner_to_orm(request.context.json)
         except Exception:
             abort(400)
-        partner_query_email= Partner.query.filter_by(contact_email=body.contact_email).first()
-        partner_query_url= Partner.query.filter_by(url=body.url).first()
+        partner_query_email = Partner.query.filter_by(
+            contact_email=body.contact_email).first()
+        partner_query_url = Partner.query.filter_by(url=body.url).first()
 
         if partner_query_email:
-            if partner_query_email.contact_email==partner.contact_email:
+            if partner_query_email.contact_email == partner.contact_email:
                 return {
                     "status": "error",
-                    "message":"Error. Entered email or url details matches existing record.",
+                    "message": "Error. Entered email or url details "
+                               + "matches existing record.",
 
-                },400
+                }, 400
         if partner_query_url:
-            if partner_query_url.url==partner.url:
+            if partner_query_url.url == partner.url:
                 return {
                     "status": "error",
-                    "message":"Error. Entered email or url details matches existing record.",
-
-                },400
-
-
+                    "message": "Error. Entered email or url details "
+                               + "matches existing record.",
+                }, 400
 
         """
-        add to database if all fields are present, and instance not already in db.
+        add to database if all fields are present
+        and instance not already in db.
         """
-        
-        
+
         created = partner.create()
         resp = jsonify(
                         {
@@ -91,7 +93,6 @@ def create():
                         }
                     )
 
-            
         make_admin = PartnerMember(
             partner_id=created.id,
             user_id=get_jwt()["sub"],
@@ -103,26 +104,19 @@ def create():
             "partner_name": partner.name,
             "partner_contact": partner.contact_email
         })
-        return resp,200
+        return resp, 200
     else:
 
         """
         missing values/fields in the form
         """
-        required_keys=["name","url","contact_email"]
+        required_keys = ["name", "url", "contact_email"]
         return {
                 "status": "error",
-                "message": "Failed to create partner. Please include all of the following"
+                "message": "Failed to create partner. " +
+                           "Please include all of the following"
                 " fields: " + ", ".join(required_keys),
         }, 400
-
-
-    
-   
-
-
-
-
 
 
 @bp.route("/", methods=["GET"])
@@ -257,7 +251,3 @@ def add_member_to_partner(partner_id: int):
         "role": partner_member.role,
     })
     return partner_member_orm_to_json(created)
-
-
-
-    


### PR DESCRIPTION
Added some code to existing create partners endpoint to handle existing instances, status codes/response, and validation

New organization/partner cannot be created if an organization already exists in db with same url or email. Partners with same name allowed, but since url/emails are unique I made it so that new partner to be added cannot have the same url/email as existing ones.