### PR TITLE
Feature #313 - Add Statewide IDs

### DIFF
--- a/backend/database/models/officer.py
+++ b/backend/database/models/officer.py
@@ -16,6 +16,23 @@ class Rank(str, enum.Enum):
     CHIEF = "CHIEF"
 
 
+class StateID(db.Model):
+    """
+    Represents a Statewide ID that follows an offcier even as they move between
+    law enforcement agencies. for an officer. For example, in New York, this
+    would be the Tax ID Number.
+    """
+    id = db.Column(db.Integer, primary_key=True)
+    officer_id = db.Column(
+        db.Integer, db.ForeignKey("officer.id"))
+    id_name = db.Column(db.Text)  # e.g. "Tax ID Number"
+    state = db.Column(db.Text)  # e.g. "NY"
+    value = db.Column(db.Text)  # e.g. "958938"
+
+    def __repr__(self):
+        return f"<StateID {self.id}>"
+
+
 class Officer(db.Model):
     id = db.Column(db.Integer, primary_key=True)  # officer id
     first_name = db.Column(db.Text)
@@ -23,9 +40,6 @@ class Officer(db.Model):
     race = db.Column(db.Text)
     ethnicity = db.Column(db.Text)
     gender = db.Column(db.Text)
-    # Note: rank at time of incident
-    rank = db.Column(db.Enum(Rank))
-    star = db.Column(db.Text)  # type?
     date_of_birth = db.Column(db.Date)
 
     def __repr__(self):

--- a/backend/database/models/officer.py
+++ b/backend/database/models/officer.py
@@ -16,6 +16,59 @@ class Rank(str, enum.Enum):
     CHIEF = "CHIEF"
 
 
+class State(str, enum.Enum):
+    AL = "AL"
+    AK = "AK"
+    AZ = "AZ"
+    AR = "AR"
+    CA = "CA"
+    CO = "CO"
+    CT = "CT"
+    DE = "DE"
+    FL = "FL"
+    GA = "GA"
+    HI = "HI"
+    ID = "ID"
+    IL = "IL"
+    IN = "IN"
+    IA = "IA"
+    KS = "KS"
+    KY = "KY"
+    LA = "LA"
+    ME = "ME"
+    MD = "MD"
+    MA = "MA"
+    MI = "MI"
+    MN = "MN"
+    MS = "MS"
+    MO = "MO"
+    MT = "MT"
+    NE = "NE"
+    NV = "NV"
+    NH = "NH"
+    NJ = "NJ"
+    NM = "NM"
+    NY = "NY"
+    NC = "NC"
+    ND = "ND"
+    OH = "OH"
+    OK = "OK"
+    OR = "OR"
+    PA = "PA"
+    RI = "RI"
+    SC = "SC"
+    SD = "SD"
+    TN = "TN"
+    TX = "TX"
+    UT = "UT"
+    VT = "VT"
+    VA = "VA"
+    WA = "WA"
+    WV = "WV"
+    WI = "WI"
+    WY = "WY"
+
+
 class StateID(db.Model):
     """
     Represents a Statewide ID that follows an offcier even as they move between
@@ -26,7 +79,7 @@ class StateID(db.Model):
     officer_id = db.Column(
         db.Integer, db.ForeignKey("officer.id"))
     id_name = db.Column(db.Text)  # e.g. "Tax ID Number"
-    state = db.Column(db.Text)  # e.g. "NY"
+    state = db.Column(db.Enum(State))  # e.g. "NY"
     value = db.Column(db.Text)  # e.g. "958938"
 
     def __repr__(self):

--- a/backend/database/models/perpetrator.py
+++ b/backend/database/models/perpetrator.py
@@ -15,7 +15,9 @@ class Perpetrator(db.Model):
     unit = db.Column(db.Text)  # type?
     # Note: rank at time of incident
     rank = db.Column(db.Enum(Rank))
-    star = db.Column(db.Text)  # type?
+    state_id_val = db.Column(db.Text)
+    state_id_state = db.Column(db.Text)
+    state_id_name = db.Column(db.Text)
     role = db.Column(db.Text)
     suspects = db.relationship(
         "Officer", secondary=perpetrator_officer, backref="accusations")

--- a/backend/database/models/perpetrator.py
+++ b/backend/database/models/perpetrator.py
@@ -1,5 +1,5 @@
 from backend.database.models._assoc_tables import perpetrator_officer
-from backend.database.models.officer import Rank
+from backend.database.models.officer import Rank, State
 from .. import db
 
 
@@ -16,7 +16,7 @@ class Perpetrator(db.Model):
     # Note: rank at time of incident
     rank = db.Column(db.Enum(Rank))
     state_id_val = db.Column(db.Text)
-    state_id_state = db.Column(db.Text)
+    state_id_state = db.Column(db.Enum(State))
     state_id_name = db.Column(db.Text)
     role = db.Column(db.Text)
     suspects = db.relationship(


### PR DESCRIPTION
Adds a StateID model as a child of the officer table. This allows the index to track statewide Officer IDs such as Tax ID or TCOLE PID numbers.