### PR TITLE
Added Simple Get Route for Incidents

### DIFF
--- a/alembic/dev_seeds.py
+++ b/alembic/dev_seeds.py
@@ -1,22 +1,22 @@
 from backend.database.core import db
 from backend.database import User, UserRole
 from backend.auth import user_manager
-from backend.database.models.incident import Incident
+from backend.database.models.incident import Incident, PrivacyStatus
 from backend.database.models.perpetrator import Perpetrator
-from backend.database.models.partner import Partner
+from backend.database.models.partner import Partner, PartnerMember, MemberRole
 from backend.database.models.use_of_force import UseOfForce
+from random import choice
+from datetime import datetime
 
 
 def create_user(user):
-    user_exists = (
-        db.session.query(User).filter_by(email=user.email).first() is not None
-    )
+    user_exists = db.session.query(User).filter_by(email=user.email).first() is not None
 
     if not user_exists:
         user.create()
 
 
-def create_partner(partner):
+def create_partner(partner: Partner) -> Partner:
     partner_exists = (
         db.session.query(Partner).filter_by(id=partner.id).first() is not None
     )
@@ -24,12 +24,13 @@ def create_partner(partner):
     if not partner_exists:
         partner.create()
 
+    return partner
 
-def create_incident(key=1, date="10-01-2019", lon=84, lat=34):
-    mpv = db.session.query(Partner).filter_by(
-        name="Mapping Police Violence").first()
+
+def create_incident(key=1, date="10-01-2019", lon=84, lat=34, partner_id=1):
     incident = Incident(
-        source_id=mpv.id,
+        source_id=partner_id,
+        source_type=choice([PrivacyStatus.PUBLIC, PrivacyStatus.PRIVATE]),
         date_record_created=f"{date} 00:00:00",
         time_of_incident=f"{date} 00:00:00",
         time_confidence="1",
@@ -53,7 +54,7 @@ def create_incident(key=1, date="10-01-2019", lon=84, lat=34):
                 last_name=f"TestLastName {key}",
             )
         ],
-        use_of_force=[UseOfForce(item=f"gunshot {key}")]
+        use_of_force=[UseOfForce(item=f"gunshot {key}")],
     )
     exists = db.session.query(Incident).filter_by(id=key).first() is not None
 
@@ -102,21 +103,29 @@ def create_seeds():
             phone_number="(012) 345-6789",
         )
     )
-    create_partner(
+    partner = create_partner(
         Partner(
             name="Mapping Police Violence",
             url="https://mappingpoliceviolence.us",
-            contact_email="info@campaignzero.org"
+            contact_email="info@campaignzero.org",
+            member_association=[
+                PartnerMember(
+                    user_id=1,
+                    role=MemberRole.MEMBER,
+                    date_joined=datetime.now(),
+                    is_active=True,
+                )
+            ],
         )
     )
-    create_incident(key=1, date="10-01-2019", lon=-84.362576, lat=33.7589748)
-    create_incident(key=2, date="11-01-2019", lon=-118.1861128, lat=33.76702)
-    create_incident(key=3, date="12-01-2019", lon=-117.8827321, lat=33.800308)
-    create_incident(key=4, date="03-15-2020", lon=-118.1690197, lat=33.8338271)
-    create_incident(key=5, date="04-15-2020", lon=-83.9007382, lat=33.8389977)
-    create_incident(key=6, date="08-10-2020", lon=-84.2687574, lat=33.9009798)
-    create_incident(key=7, date="10-01-2020", lon=-118.40853, lat=33.9415889)
-    create_incident(key=8, date="10-15-2020", lon=-84.032149, lat=33.967774)
+    create_incident(key=1, date="10-01-2019", lon=-84.362576, lat=33.7589748, partner_id=partner.id)
+    create_incident(key=2, date="11-01-2019", lon=-118.1861128, lat=33.76702, partner_id=partner.id)
+    create_incident(key=3, date="12-01-2019", lon=-117.8827321, lat=33.800308, partner_id=partner.id)
+    create_incident(key=4, date="03-15-2020", lon=-118.1690197, lat=33.8338271, partner_id=partner.id)
+    create_incident(key=5, date="04-15-2020", lon=-83.9007382, lat=33.8389977, partner_id=partner.id)
+    create_incident(key=6, date="08-10-2020", lon=-84.2687574, lat=33.9009798, partner_id=partner.id)
+    create_incident(key=7, date="10-01-2020", lon=-118.40853, lat=33.9415889, partner_id=partner.id)
+    create_incident(key=8, date="10-15-2020", lon=-84.032149, lat=33.967774, partner_id=partner.id)
 
 
 create_seeds()

--- a/alembic/dev_seeds.py
+++ b/alembic/dev_seeds.py
@@ -10,7 +10,9 @@ from datetime import datetime
 
 
 def create_user(user):
-    user_exists = db.session.query(User).filter_by(email=user.email).first() is not None
+    user_exists = (
+        db.session.query(User).filter_by(email=user.email).first() is not None
+    )
 
     if not user_exists:
         user.create()
@@ -30,7 +32,7 @@ def create_partner(partner: Partner) -> Partner:
 def create_incident(key=1, date="10-01-2019", lon=84, lat=34, partner_id=1):
     incident = Incident(
         source_id=partner_id,
-        source_type=choice([PrivacyStatus.PUBLIC, PrivacyStatus.PRIVATE]),
+        privacy_filter=choice([PrivacyStatus.PUBLIC, PrivacyStatus.PRIVATE]),
         date_record_created=f"{date} 00:00:00",
         time_of_incident=f"{date} 00:00:00",
         time_confidence="1",
@@ -118,14 +120,62 @@ def create_seeds():
             ],
         )
     )
-    create_incident(key=1, date="10-01-2019", lon=-84.362576, lat=33.7589748, partner_id=partner.id)
-    create_incident(key=2, date="11-01-2019", lon=-118.1861128, lat=33.76702, partner_id=partner.id)
-    create_incident(key=3, date="12-01-2019", lon=-117.8827321, lat=33.800308, partner_id=partner.id)
-    create_incident(key=4, date="03-15-2020", lon=-118.1690197, lat=33.8338271, partner_id=partner.id)
-    create_incident(key=5, date="04-15-2020", lon=-83.9007382, lat=33.8389977, partner_id=partner.id)
-    create_incident(key=6, date="08-10-2020", lon=-84.2687574, lat=33.9009798, partner_id=partner.id)
-    create_incident(key=7, date="10-01-2020", lon=-118.40853, lat=33.9415889, partner_id=partner.id)
-    create_incident(key=8, date="10-15-2020", lon=-84.032149, lat=33.967774, partner_id=partner.id)
+    create_incident(
+        key=1,
+        date="10-01-2019",
+        lon=-84.362576,
+        lat=33.7589748,
+        partner_id=partner.id,
+    )
+    create_incident(
+        key=2,
+        date="11-01-2019",
+        lon=-118.1861128,
+        lat=33.76702,
+        partner_id=partner.id,
+    )
+    create_incident(
+        key=3,
+        date="12-01-2019",
+        lon=-117.8827321,
+        lat=33.800308,
+        partner_id=partner.id,
+    )
+    create_incident(
+        key=4,
+        date="03-15-2020",
+        lon=-118.1690197,
+        lat=33.8338271,
+        partner_id=partner.id,
+    )
+    create_incident(
+        key=5,
+        date="04-15-2020",
+        lon=-83.9007382,
+        lat=33.8389977,
+        partner_id=partner.id,
+    )
+    create_incident(
+        key=6,
+        date="08-10-2020",
+        lon=-84.2687574,
+        lat=33.9009798,
+        partner_id=partner.id,
+    )
+    create_incident(
+        key=7,
+        date="10-01-2020",
+        lon=-118.40853,
+        lat=33.9415889,
+        partner_id=partner.id,
+    )
+    create_incident(
+        key=8,
+        date="10-15-2020",
+        lon=-84.032149,
+        lat=33.967774,
+        partner_id=partner.id,
+    )
 
 
 create_seeds()

--- a/backend/database/models/incident.py
+++ b/backend/database/models/incident.py
@@ -1,9 +1,10 @@
 """Define the SQL classes for Users."""
+from __future__ import annotations  # allows type hinting of class itself
 import enum
 from datetime import datetime
-
 from ..core import CrudMixin, db
 from backend.database.models._assoc_tables import incident_agency, incident_tag
+from sqlalchemy.orm import RelationshipProperty
 
 
 class RecordType(enum.Enum):
@@ -57,13 +58,20 @@ class VictimStatus(enum.Enum):
 
 
 class Incident(db.Model, CrudMixin):
+
     """The incident table is the fact table."""
 
+    # Just a note: this only explicitly used for type hinting
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    source_id = db.Column(
-        db.Integer, db.ForeignKey("partner.id"))
+    source_id: RelationshipProperty[int] = db.Column(
+        db.Integer, db.ForeignKey("partner.id")
+    )
     source_details = db.relationship(
-        "SourceDetails", backref="incident", uselist=False)
+        "SourceDetails", backref="incident", uselist=False
+    )
     date_record_created = db.Column(db.DateTime)
     time_of_incident = db.Column(db.DateTime)
     time_confidence = db.Column(db.Integer)
@@ -89,7 +97,8 @@ class Incident(db.Model, CrudMixin):
     # descriptions = db.relationship("Description", backref="incident")
     tags = db.relationship("Tag", secondary=incident_tag, backref="incidents")
     agencies_present = db.relationship(
-        "Agency", secondary=incident_agency, backref="recorded_incidents")
+        "Agency", secondary=incident_agency, backref="recorded_incidents"
+    )
     participants = db.relationship("Participant", backref="incident")
     attachments = db.relationship("Attachment", backref="incident")
     investigations = db.relationship("Investigation", backref="incident")
@@ -119,22 +128,22 @@ class Incident(db.Model, CrudMixin):
 #     )
 #     text = db.Column(db.Text)
 #     type = db.Column(db.Text)  # TODO: enum
-    # TODO: are there rules for this column other than text?
-    # organization_id = db.Column(db.Text)
-    # location = db.Column(db.Text)  # TODO: location object
-    # # TODO: neighborhood seems like a weird identifier that may not always
-    # #  apply in consistent ways across municipalities.
-    # neighborhood = db.Column(db.Text)
-    # stop_type = db.Column(db.Text)  # TODO: enum
-    # call_type = db.Column(db.Text)  # TODO: enum
-    # has_multimedia = db.Column(db.Boolean)
-    # from_report = db.Column(db.Boolean)
-    # # These may require an additional table. Also can dox a victim
-    # was_victim_arrested = db.Column(db.Boolean)
-    # arrest_id = db.Column(db.Integer)  # TODO: foreign key of some sort?
-    # # Does an existing warrant count here?
-    # criminal_case_brought = db.Column(db.Boolean)
-    # case_id = db.Column(db.Integer)  # TODO: foreign key of some sort?
+# TODO: are there rules for this column other than text?
+# organization_id = db.Column(db.Text)
+# location = db.Column(db.Text)  # TODO: location object
+# # TODO: neighborhood seems like a weird identifier that may not always
+# #  apply in consistent ways across municipalities.
+# neighborhood = db.Column(db.Text)
+# stop_type = db.Column(db.Text)  # TODO: enum
+# call_type = db.Column(db.Text)  # TODO: enum
+# has_multimedia = db.Column(db.Boolean)
+# from_report = db.Column(db.Boolean)
+# # These may require an additional table. Also can dox a victim
+# was_victim_arrested = db.Column(db.Boolean)
+# arrest_id = db.Column(db.Integer)  # TODO: foreign key of some sort?
+# # Does an existing warrant count here?
+# criminal_case_brought = db.Column(db.Boolean)
+# case_id = db.Column(db.Integer)  # TODO: foreign key of some sort?
 
 
 class SourceDetails(db.Model):

--- a/backend/database/models/incident.py
+++ b/backend/database/models/incident.py
@@ -74,7 +74,9 @@ class Incident(db.Model, CrudMixin):
     source_id: RelationshipProperty[int] = db.Column(
         db.Integer, db.ForeignKey("partner.id")
     )
-    source_details = db.relationship("SourceDetails", backref="incident", uselist=False)
+    source_details = db.relationship(
+        "SourceDetails", backref="incident", uselist=False
+    )
     source_type = db.Column(db.Enum(PrivacyStatus))
     date_record_created = db.Column(db.DateTime)
     time_of_incident = db.Column(db.DateTime)
@@ -152,7 +154,9 @@ class Incident(db.Model, CrudMixin):
 
 class SourceDetails(db.Model):
     id = db.Column(db.Integer, primary_key=True)  # source details id
-    incident_id = db.Column(db.Integer, db.ForeignKey("incident.id"), nullable=False)
+    incident_id = db.Column(
+        db.Integer, db.ForeignKey("incident.id"), nullable=False
+    )
     record_type = db.Column(db.Enum(RecordType))
     # For Journalistic Publications
     publication_name = db.Column(db.Text)

--- a/backend/database/models/incident.py
+++ b/backend/database/models/incident.py
@@ -77,7 +77,7 @@ class Incident(db.Model, CrudMixin):
     source_details = db.relationship(
         "SourceDetails", backref="incident", uselist=False
     )
-    source_type = db.Column(db.Enum(PrivacyStatus))
+    privacy_filter = db.Column(db.Enum(PrivacyStatus))
     date_record_created = db.Column(db.DateTime)
     time_of_incident = db.Column(db.DateTime)
     time_confidence = db.Column(db.Integer)

--- a/backend/database/models/incident.py
+++ b/backend/database/models/incident.py
@@ -57,6 +57,11 @@ class VictimStatus(enum.Enum):
     DECEASED = 5
 
 
+class PrivacyStatus(str, enum.Enum):
+    PUBLIC = "PUBLIC"
+    PRIVATE = "PRIVATE"
+
+
 class Incident(db.Model, CrudMixin):
 
     """The incident table is the fact table."""
@@ -69,9 +74,8 @@ class Incident(db.Model, CrudMixin):
     source_id: RelationshipProperty[int] = db.Column(
         db.Integer, db.ForeignKey("partner.id")
     )
-    source_details = db.relationship(
-        "SourceDetails", backref="incident", uselist=False
-    )
+    source_details = db.relationship("SourceDetails", backref="incident", uselist=False)
+    source_type = db.Column(db.Enum(PrivacyStatus))
     date_record_created = db.Column(db.DateTime)
     time_of_incident = db.Column(db.DateTime)
     time_confidence = db.Column(db.Integer)
@@ -148,9 +152,7 @@ class Incident(db.Model, CrudMixin):
 
 class SourceDetails(db.Model):
     id = db.Column(db.Integer, primary_key=True)  # source details id
-    incident_id = db.Column(
-        db.Integer, db.ForeignKey("incident.id"), nullable=False
-    )
+    incident_id = db.Column(db.Integer, db.ForeignKey("incident.id"), nullable=False)
     record_type = db.Column(db.Enum(RecordType))
     # For Journalistic Publications
     publication_name = db.Column(db.Text)

--- a/backend/database/models/partner.py
+++ b/backend/database/models/partner.py
@@ -1,5 +1,6 @@
-
+from __future__ import annotations  # allows type hinting of class itself
 from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.orm import RelationshipProperty
 from ..core import db, CrudMixin
 from enum import Enum
 from datetime import datetime
@@ -27,10 +28,10 @@ class MemberRole(str, Enum):
 class PartnerMember(db.Model, CrudMixin):
     __tablename__ = "partner_user"
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    partner_id = db.Column(db.Integer, db.ForeignKey('partner.id'),
-                           primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'),
-                        primary_key=True)
+    partner_id = db.Column(
+        db.Integer, db.ForeignKey("partner.id"), primary_key=True
+    )
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), primary_key=True)
     user = db.relationship("User", back_populates="partner_association")
     partner = db.relationship("Partner", back_populates="member_association")
     role = db.Column(db.Enum(MemberRole))
@@ -53,10 +54,12 @@ class Partner(db.Model, CrudMixin):
     name = db.Column(db.Text)
     url = db.Column(db.Text)
     contact_email = db.Column(db.Text)
-    reported_incidents = db.relationship(
-        'Incident', backref='source', lazy="select")
-    member_association = db.relationship(
-        'PartnerMember', back_populates="partner", lazy="select")
+    reported_incidents: RelationshipProperty[int] = db.relationship(
+        "Incident", backref="source", lazy="select"
+    )
+    member_association: RelationshipProperty[PartnerMember] = db.relationship(
+        "PartnerMember", back_populates="partner", lazy="select"
+    )
     members = association_proxy("member_association", "user")
 
     def __repr__(self):

--- a/backend/database/models/partner.py
+++ b/backend/database/models/partner.py
@@ -26,11 +26,13 @@ class MemberRole(str, Enum):
 
 
 class PartnerMember(db.Model, CrudMixin):
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
     __tablename__ = "partner_user"
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    partner_id = db.Column(
-        db.Integer, db.ForeignKey("partner.id"), primary_key=True
-    )
+    partner_id = db.Column(db.Integer, db.ForeignKey("partner.id"), primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), primary_key=True)
     user = db.relationship("User", back_populates="partner_association")
     partner = db.relationship("Partner", back_populates="member_association")
@@ -47,9 +49,14 @@ class PartnerMember(db.Model, CrudMixin):
     def create(self, refresh: bool = True):
         self.date_joined = datetime.now()
         return super().create(refresh)
+    
+        
 
 
 class Partner(db.Model, CrudMixin):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     name = db.Column(db.Text)
     url = db.Column(db.Text)

--- a/backend/database/models/partner.py
+++ b/backend/database/models/partner.py
@@ -26,13 +26,14 @@ class MemberRole(str, Enum):
 
 
 class PartnerMember(db.Model, CrudMixin):
-    
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
     __tablename__ = "partner_user"
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    partner_id = db.Column(db.Integer, db.ForeignKey("partner.id"), primary_key=True)
+    partner_id = db.Column(
+        db.Integer, db.ForeignKey("partner.id"), primary_key=True
+    )
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), primary_key=True)
     user = db.relationship("User", back_populates="partner_association")
     partner = db.relationship("Partner", back_populates="member_association")
@@ -49,8 +50,6 @@ class PartnerMember(db.Model, CrudMixin):
     def create(self, refresh: bool = True):
         self.date_joined = datetime.now()
         return super().create(refresh)
-    
-        
 
 
 class Partner(db.Model, CrudMixin):

--- a/backend/routes/partners.py
+++ b/backend/routes/partners.py
@@ -292,7 +292,7 @@ def get_incidents(partner_id: int):
     pagination: Pagination
     if user_id not in [user.id for user in partner.members]:
         pagination = Incident.query.filter_by(
-            source_id=partner_id, source_type=PrivacyStatus.PUBLIC
+            source_id=partner_id, privacy_filter=PrivacyStatus.PUBLIC
         ).paginate(page=page, per_page=per_page, error_out=False)
     else:
         pagination = Incident.query.filter_by(source_id=partner_id).paginate(

--- a/backend/routes/partners.py
+++ b/backend/routes/partners.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from backend.auth.jwt import min_role_required
 from backend.mixpanel.mix import track_to_mp
 from backend.database.models.user import User, UserRole
@@ -5,7 +7,7 @@ from flask import Blueprint, abort, current_app, request
 from flask_jwt_extended import get_jwt
 from flask_jwt_extended.view_decorators import jwt_required
 from flask_sqlalchemy import Pagination
-from ..database import Partner, PartnerMember, MemberRole, db
+from ..database import Partner, PartnerMember, MemberRole, db, Incident
 from ..schemas import (
     CreatePartnerSchema,
     AddMemberSchema,
@@ -15,7 +17,9 @@ from ..schemas import (
     partner_member_to_orm,
     partner_to_orm,
     validate,
+    incident_orm_to_json,
 )
+
 
 bp = Blueprint("partner_routes", __name__, url_prefix="/api/v1/partners")
 
@@ -146,6 +150,9 @@ def get_partner_members(partner_id: int):
 @min_role_required(UserRole.PUBLIC)
 @validate()  # type: ignore
 def get_partner_users(partner_id: int):
+    # check if the partner exists
+    partner = Partner.get(partner_id)
+
     # Get the page number from the query parameters (default to 1)
     page = request.args.get("page", 1, type=int)
 
@@ -155,12 +162,8 @@ def get_partner_users(partner_id: int):
     # Query the PartnerMember table for records with
     # the given partner_id and paginate the results
     pagination: Pagination = PartnerMember.query.filter_by(
-        partner_id=partner_id
+        partner_id=partner.id
     ).paginate(page=page, per_page=per_page, error_out=False)
-
-    # If the partner_id is invalid, return a 404 error
-    if pagination.total == 0:
-        return {"message": "Partner not found"}, 404
 
     # Get the User objects associated with the members on the current page
     users: list[User] = [
@@ -242,3 +245,44 @@ def add_member_to_partner(partner_id: int):
         },
     )
     return partner_member_orm_to_json(created)
+
+
+@bp.route("/<int:partner_id>/incidents", methods=["GET"])
+@jwt_required()  # type: ignore
+@min_role_required(UserRole.PUBLIC)
+@validate()  # type: ignore
+def get_incidents(partner_id: int):
+    """
+    Get all incidents associated with a partner.
+
+    Accepts Query Parameters for pagination:
+    per_page: number of results per page
+    page: page number
+    """
+
+    # check if the partner exists
+    partner: Partner = Partner.get(partner_id)  # type: ignore
+
+    # Get the page number from the query parameters (default to 1)
+    page = request.args.get("page", 1, type=int)
+
+    # Get the number of items per page from the query parameters (default to 20)
+    per_page = request.args.get("per_page", 20, type=int)
+
+    # Query the Incident table for records with the given partner_id
+    # and paginate the results
+    pagination: Any = Incident.query.filter_by(source_id=partner.id).paginate(
+        page=page, per_page=per_page, error_out=False
+    )
+
+    incidents: list[dict[str, Any]] = [
+        incident_orm_to_json(incident) for incident in pagination.items
+    ]
+
+    # Convert the Incident objects to dictionaries and return them as JSON
+    return {
+        "results": incidents,
+        "page": pagination.page,
+        "totalPages": pagination.pages,
+        "totalResults": pagination.total,
+    }

--- a/backend/routes/partners.py
+++ b/backend/routes/partners.py
@@ -7,7 +7,14 @@ from flask import Blueprint, abort, current_app, request
 from flask_jwt_extended import get_jwt
 from flask_jwt_extended.view_decorators import jwt_required
 from flask_sqlalchemy import Pagination
-from ..database import Partner, PartnerMember, MemberRole, db, Incident, PrivacyStatus
+from ..database import (
+    Partner,
+    PartnerMember,
+    MemberRole,
+    db,
+    Incident,
+    PrivacyStatus,
+)
 from ..schemas import (
     CreatePartnerSchema,
     AddMemberSchema,
@@ -85,7 +92,9 @@ def get_all_partners():
     q_per_page = args.get("per_page", 20, type=int)
 
     all_partners = db.session.query(Partner)
-    results = all_partners.paginate(page=q_page, per_page=q_per_page, max_per_page=100)
+    results = all_partners.paginate(
+        page=q_page, per_page=q_per_page, max_per_page=100
+    )
 
     return {
         "results": [partner_orm_to_json(partner) for partner in results.items],
@@ -113,10 +122,14 @@ def get_partner_members(partner_id: int):
     all_members = db.session.query(PartnerMember).filter(
         PartnerMember.partner_id == partner_id
     )
-    results = all_members.paginate(page=q_page, per_page=q_per_page, max_per_page=100)
+    results = all_members.paginate(
+        page=q_page, per_page=q_per_page, max_per_page=100
+    )
 
     return {
-        "results": [partner_member_orm_to_json(member) for member in results.items],
+        "results": [
+            partner_member_orm_to_json(member) for member in results.items
+        ],
         "page": results.page,
         "totalPages": results.pages,
         "totalResults": results.total,
@@ -160,7 +173,9 @@ def get_partner_users(partner_id: int):
     ).paginate(page=page, per_page=per_page, error_out=False)
 
     # Get the User objects associated with the members on the current page
-    users: list[User] = [User.query.get(member.user_id) for member in pagination.items]  # type: ignore
+    users: list[User] = [
+        User.query.get(member.user_id) for member in pagination.items
+    ]  # type: ignore
 
     # Convert the User objects to dictionaries and return them as JSON
 
@@ -253,7 +268,8 @@ def get_incidents(partner_id: int):
 
     :param partner_id: The ID of the partner
     :type partner_id: int
-    :return: A dictionary containing the results, page number, total pages, and total results
+    :return: A dictionary containing the results, page number,
+    total pages, and total results
     :rtype: dict
     """
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -114,7 +114,7 @@ def example_incidents(db_session: Any, example_partner: Partner):
     incidents = [
         Incident(
             source_id=example_partner.id,
-            source_type=PrivacyStatus.PUBLIC,
+            privacy_filter=PrivacyStatus.PUBLIC,
             date_record_created=datetime.now(),
             time_of_incident=datetime.now(),
             time_confidence=90,
@@ -133,7 +133,7 @@ def example_incidents(db_session: Any, example_partner: Partner):
         ),
         Incident(
             source_id=example_partner.id,
-            source_type=PrivacyStatus.PUBLIC,
+            privacy_filter=PrivacyStatus.PUBLIC,
             date_record_created=datetime.now(),
             time_of_incident=datetime.now(),
             time_confidence=90,
@@ -152,7 +152,7 @@ def example_incidents(db_session: Any, example_partner: Partner):
         ),
         Incident(
             source_id=example_partner.id,
-            source_type=PrivacyStatus.PUBLIC,
+            privacy_filter=PrivacyStatus.PUBLIC,
             date_record_created=datetime.now(),
             time_of_incident=datetime.now(),
             time_confidence=90,
@@ -184,7 +184,7 @@ def example_incidents_private_public(
     incidents = [
         Incident(
             source_id=example_partner_member.id,
-            source_type=PrivacyStatus.PUBLIC,
+            privacy_filter=PrivacyStatus.PUBLIC,
             date_record_created=datetime.now(),
             time_of_incident=datetime.now(),
             time_confidence=90,
@@ -203,7 +203,7 @@ def example_incidents_private_public(
         ),
         Incident(
             source_id=example_partner_member.id,
-            source_type=PrivacyStatus.PRIVATE,
+            privacy_filter=PrivacyStatus.PRIVATE,
             date_record_created=datetime.now(),
             time_of_incident=datetime.now(),
             time_confidence=90,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,10 +4,11 @@ from backend.api import create_app
 from backend.auth import user_manager
 from backend.config import TestingConfig
 from backend.database import User, UserRole, db
-from backend.database import Partner, PartnerMember, MemberRole
+from backend.database import Partner, PartnerMember, MemberRole, Incident
 from datetime import datetime
 from pytest_postgresql.janitor import DatabaseJanitor
 from sqlalchemy import insert
+from typing import Any
 
 example_email = "test@email.com"
 admin_email = "admin@email.com"
@@ -81,6 +82,35 @@ def example_user(db_session):
     return user
 
 
+@pytest.fixture  # type: ignore
+def example_incidents(db_session: Any, example_partner: Partner):
+    incidents = [
+        Incident(
+            source_id=example_partner.id,
+            date_record_created=datetime.now(),
+            time_of_incident=datetime.now(),
+            time_confidence=90,
+            complaint_date=datetime.now().date(),
+            closed_date=datetime.now().date(),
+            location="Location 1",
+            longitude=12.34,
+            latitude=56.78,
+            description="Description 1",
+            stop_type="Stop Type 1",
+            call_type="Call Type 1",
+            has_attachments=True,
+            from_report=True,
+            was_victim_arrested=False,
+            criminal_case_brought=True,
+        )
+    ]
+    for incident in incidents:
+        db_session.add(incident)
+    db_session.commit()
+
+    return incidents
+
+
 @pytest.fixture
 def admin_user(db_session):
     user = User(
@@ -102,7 +132,7 @@ def partner_admin(db_session, example_partner):
         email=p_admin_email,
         password=user_manager.hash_password(example_password),
         role=UserRole.CONTRIBUTOR,  # This is not a system admin,
-                                    # so we can't use ADMIN here
+        # so we can't use ADMIN here
         first_name="contributor",
         last_name="last",
         phone_number="(012) 345-6789",
@@ -110,9 +140,11 @@ def partner_admin(db_session, example_partner):
     db_session.add(user)
     db_session.commit()
     insert_statement = insert(PartnerMember).values(
-        partner_id=example_partner.id, user_id=user.id,
-        role=MemberRole.ADMIN, date_joined=datetime.now(),
-        is_active=True
+        partner_id=example_partner.id,
+        user_id=user.id,
+        role=MemberRole.ADMIN,
+        date_joined=datetime.now(),
+        is_active=True,
     )
     db_session.execute(insert_statement)
     db_session.commit()
@@ -127,14 +159,16 @@ def partner_publisher(db_session, example_partner):
         password=user_manager.hash_password(example_password),
         role=UserRole.CONTRIBUTOR,
         first_name="contributor",
-        last_name="last"
+        last_name="last",
     )
     db_session.add(user)
     db_session.commit()
     insert_statement = insert(PartnerMember).values(
-        partner_id=example_partner.id, user_id=user.id,
-        role=MemberRole.PUBLISHER, date_joined=datetime.now(),
-        is_active=True
+        partner_id=example_partner.id,
+        user_id=user.id,
+        role=MemberRole.PUBLISHER,
+        date_joined=datetime.now(),
+        is_active=True,
     )
     db_session.execute(insert_statement)
     db_session.commit()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,7 +4,7 @@ from backend.api import create_app
 from backend.auth import user_manager
 from backend.config import TestingConfig
 from backend.database import User, UserRole, db
-from backend.database import Partner, PartnerMember, MemberRole, Incident
+from backend.database import Partner, PartnerMember, MemberRole, Incident, PrivacyStatus
 from datetime import datetime
 from pytest_postgresql.janitor import DatabaseJanitor
 from sqlalchemy import insert
@@ -56,18 +56,6 @@ def client(app):
 
 
 @pytest.fixture
-def example_partner(db_session):
-    partner = Partner(
-        name="Example Partner",
-        url="www.example.com",
-        contact_email=contributor_email,
-    )
-    db_session.add(partner)
-    db_session.commit()
-    return partner
-
-
-@pytest.fixture
 def example_user(db_session):
     user = User(
         email=example_email,
@@ -82,11 +70,45 @@ def example_user(db_session):
     return user
 
 
+@pytest.fixture
+def example_partner(db_session: Any):
+    partner = Partner(
+        name="Example Partner",
+        url="www.example.com",
+        contact_email=contributor_email,
+        member_association=[],
+    )
+    db_session.add(partner)
+    db_session.commit()
+    return partner
+
+
+@pytest.fixture # type: ignore
+def example_partner_member(db_session: Any, example_user: User):
+    partner = Partner(
+        name="Example Partner Member",
+        url="www.example.com",
+        contact_email="example_test@example.ca",
+        member_association=[
+            PartnerMember(
+                user_id=example_user.id,
+                role=MemberRole.MEMBER,
+                date_joined=datetime.now(),
+                is_active=True,
+            )
+        ],
+    )
+    db_session.add(partner)
+    db_session.commit()
+    return partner
+
+
 @pytest.fixture  # type: ignore
 def example_incidents(db_session: Any, example_partner: Partner):
     incidents = [
         Incident(
             source_id=example_partner.id,
+            source_type=PrivacyStatus.PUBLIC,
             date_record_created=datetime.now(),
             time_of_incident=datetime.now(),
             time_confidence=90,
@@ -102,7 +124,93 @@ def example_incidents(db_session: Any, example_partner: Partner):
             from_report=True,
             was_victim_arrested=False,
             criminal_case_brought=True,
-        )
+        ),
+        Incident(
+            source_id=example_partner.id,
+            source_type=PrivacyStatus.PUBLIC,
+            date_record_created=datetime.now(),
+            time_of_incident=datetime.now(),
+            time_confidence=90,
+            complaint_date=datetime.now().date(),
+            closed_date=datetime.now().date(),
+            location="Location 1",
+            longitude=12.34,
+            latitude=56.78,
+            description="Description 1",
+            stop_type="Stop Type 1",
+            call_type="Call Type 1",
+            has_attachments=True,
+            from_report=True,
+            was_victim_arrested=False,
+            criminal_case_brought=True,
+        ),
+        Incident(
+            source_id=example_partner.id,
+            source_type=PrivacyStatus.PUBLIC,
+            date_record_created=datetime.now(),
+            time_of_incident=datetime.now(),
+            time_confidence=90,
+            complaint_date=datetime.now().date(),
+            closed_date=datetime.now().date(),
+            location="Location 1",
+            longitude=12.34,
+            latitude=56.78,
+            description="Description 1",
+            stop_type="Stop Type 1",
+            call_type="Call Type 1",
+            has_attachments=True,
+            from_report=True,
+            was_victim_arrested=False,
+            criminal_case_brought=True,
+        ),
+    ]
+    for incident in incidents:
+        db_session.add(incident)
+    db_session.commit()
+
+    return incidents
+
+@pytest.fixture  # type: ignore
+def example_incidents_private_public(db_session: Any, example_partner_member: Partner):
+    incidents = [
+        Incident(
+            source_id=example_partner_member.id,
+            source_type=PrivacyStatus.PUBLIC,
+            date_record_created=datetime.now(),
+            time_of_incident=datetime.now(),
+            time_confidence=90,
+            complaint_date=datetime.now().date(),
+            closed_date=datetime.now().date(),
+            location="Location 1",
+            longitude=12.34,
+            latitude=56.78,
+            description="Description 1",
+            stop_type="Stop Type 1",
+            call_type="Call Type 1",
+            has_attachments=True,
+            from_report=True,
+            was_victim_arrested=False,
+            criminal_case_brought=True,
+        ),
+        Incident(
+            source_id=example_partner_member.id,
+            source_type=PrivacyStatus.PRIVATE,
+            date_record_created=datetime.now(),
+            time_of_incident=datetime.now(),
+            time_confidence=90,
+            complaint_date=datetime.now().date(),
+            closed_date=datetime.now().date(),
+            location="Location 1",
+            longitude=12.34,
+            latitude=56.78,
+            description="Description 1",
+            stop_type="Stop Type 1",
+            call_type="Call Type 1",
+            has_attachments=True,
+            from_report=True,
+            was_victim_arrested=False,
+            criminal_case_brought=True,
+        ),
     ]
     for incident in incidents:
         db_session.add(incident)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,7 +4,13 @@ from backend.api import create_app
 from backend.auth import user_manager
 from backend.config import TestingConfig
 from backend.database import User, UserRole, db
-from backend.database import Partner, PartnerMember, MemberRole, Incident, PrivacyStatus
+from backend.database import (
+    Partner,
+    PartnerMember,
+    MemberRole,
+    Incident,
+    PrivacyStatus,
+)
 from datetime import datetime
 from pytest_postgresql.janitor import DatabaseJanitor
 from sqlalchemy import insert
@@ -83,7 +89,7 @@ def example_partner(db_session: Any):
     return partner
 
 
-@pytest.fixture # type: ignore
+@pytest.fixture  # type: ignore
 def example_partner_member(db_session: Any, example_user: User):
     partner = Partner(
         name="Example Partner Member",
@@ -170,8 +176,11 @@ def example_incidents(db_session: Any, example_partner: Partner):
 
     return incidents
 
+
 @pytest.fixture  # type: ignore
-def example_incidents_private_public(db_session: Any, example_partner_member: Partner):
+def example_incidents_private_public(
+    db_session: Any, example_partner_member: Partner
+):
     incidents = [
         Incident(
             source_id=example_partner_member.id,

--- a/backend/tests/test_partners.py
+++ b/backend/tests/test_partners.py
@@ -2,7 +2,7 @@ import pytest
 from backend.auth import user_manager
 from backend.database import Partner, PartnerMember, MemberRole, Incident
 from backend.database.models.user import User, UserRole
-from typing import Any
+from typing import Any, List
 
 publisher_email = "pub@partner.com"
 inactive_email = "lurker@partner.com"
@@ -326,7 +326,7 @@ def test_get_incidents(
     client: Any,
     example_partner: Partner,
     access_token: str,
-    example_incidents: list[Incident],
+    example_incidents: List[Incident],
 ) -> None:
     # Test getting incidents for the partner
     res = client.get(
@@ -371,7 +371,7 @@ def test_get_incidents_pagination(
     client: Any,
     access_token: str,
     example_partner: Partner,
-    example_incidents: list[Incident],
+    example_incidents: List[Incident],
 ) -> None:
     # Test getting incidents for the partner
     res = client.get(

--- a/backend/tests/test_partners.py
+++ b/backend/tests/test_partners.py
@@ -1,6 +1,6 @@
 import pytest
 from backend.auth import user_manager
-from backend.database import Partner, PartnerMember, MemberRole
+from backend.database import Partner, PartnerMember, MemberRole, Incident
 from backend.database.models.user import User, UserRole
 from typing import Any
 
@@ -311,6 +311,8 @@ def test_get_partner_users(
 def test_get_partner_users_error(
     client: Any,
     access_token: str,
+    example_partner: Partner,
+    example_members: PartnerMember,
 ) -> None:
     # Test that we can get partner users
     res: Any = client.get(
@@ -318,4 +320,82 @@ def test_get_partner_users_error(
         headers={"Authorization": "Bearer {0}".format(access_token)},
     )
     assert res.status_code == 404
-    assert res.get_json()["message"] == "Partner not found"
+
+
+def test_get_incidents(
+    client: Any,
+    example_partner: Partner,
+    access_token: str,
+    example_incidents: list[Incident],
+) -> None:
+    # Test getting incidents for the partner
+    res = client.get(
+        f"/api/v1/partners/{example_partner.id}/incidents",
+        headers={"Authorization": "Bearer {0}".format(access_token)},
+    )
+    assert res.status_code == 200
+    data = res.get_json()
+
+    # Verify the response structure
+    assert "results" in data
+    assert "page" in data
+    assert "totalPages" in data
+    assert "totalResults" in data
+
+    # Verify the results
+    assert len(data["results"]) == len(example_incidents)
+
+    # Verify the page number
+    assert data["page"] == 1
+
+    # Verify the total pages
+    assert data["totalPages"] == 1
+
+    # Verify the total results
+    assert data["totalResults"] == len(example_incidents)
+
+
+def test_get_incidents_partner_not_found(
+    client: Any,
+    access_token: str,
+) -> None:
+    # Test getting incidents for the partner
+    res = client.get(
+        f"/api/v1/partners/{9999}/incidents",
+        headers={"Authorization": "Bearer {0}".format(access_token)},
+    )
+    assert res.status_code == 404
+
+
+def test_get_incidents_pagination(
+    client: Any,
+    access_token: str,
+    example_partner: Partner,
+    example_incidents: list[Incident],
+) -> None:
+    # Test getting incidents for the partner
+    res = client.get(
+        f"/api/v1/partners/{example_partner.id}/incidents",
+        headers={"Authorization": "Bearer {0}".format(access_token)},
+    )
+
+    assert res.status_code == 200
+    data = res.get_json()
+
+    # Verify the response structure
+    assert "results" in data
+    assert "page" in data
+    assert "totalPages" in data
+    assert "totalResults" in data
+
+    # Verify the results
+    assert len(data["results"]) == len(example_incidents)
+
+    # Verify the page number
+    assert data["page"] == 1
+
+    # Verify the total pages
+    assert data["totalPages"] == 1
+
+    # Verify the total results
+    assert data["totalResults"] == len(example_incidents)

--- a/backend/tests/test_partners.py
+++ b/backend/tests/test_partners.py
@@ -105,12 +105,16 @@ def example_members(client, db_session, example_partner, p_admin_access_token):
         users[id] = user
 
     partner_obj = (
-        db_session.query(Partner).filter(Partner.name == example_partner.name).first()
+        db_session.query(Partner)
+        .filter(Partner.name == example_partner.name)
+        .first()
     )
 
     for id, mock in mock_members.items():
         user_obj = (
-            db_session.query(User).filter(User.email == mock["user_email"]).first()
+            db_session.query(User)
+            .filter(User.email == mock["user_email"])
+            .first()
         )
 
         req = {
@@ -123,7 +127,9 @@ def example_members(client, db_session, example_partner, p_admin_access_token):
         res = client.post(
             f"/api/v1/partners/{partner_obj.id}/members/add",
             json=req,
-            headers={"Authorization": "Bearer {0}".format(p_admin_access_token)},
+            headers={
+                "Authorization": "Bearer {0}".format(p_admin_access_token)
+            },
         )
         assert res.status_code == 200
         created[id] = res.json
@@ -134,10 +140,14 @@ def test_create_partner(db_session, example_user, example_partners):
     created = example_partners["mpv"]
 
     partner_obj = (
-        db_session.query(Partner).filter(Partner.name == created["name"]).first()
+        db_session.query(Partner)
+        .filter(Partner.name == created["name"])
+        .first()
     )
 
-    user_obj = db_session.query(User).filter(User.email == example_user.email).first()
+    user_obj = (
+        db_session.query(User).filter(User.email == example_user.email).first()
+    )
 
     association_obj = (
         db_session.query(PartnerMember)
@@ -202,7 +212,10 @@ def test_partner_pagination(client, example_partners, access_token):
     assert actual_ids == set(i["id"] for i in example_partners.values())
 
     res = client.get(
-        (f"/api/v1/partners/?per_page={per_page}" f"&page={expected_total_pages + 1}"),
+        (
+            f"/api/v1/partners/?per_page={per_page}"
+            f"&page={expected_total_pages + 1}"
+        ),
         headers={"Authorization": "Bearer {0}".format(access_token)},
     )
     assert res.status_code == 404
@@ -228,18 +241,26 @@ def test_get_partner_members(
     # Create partners in the database
     users = []
     partner_obj = (
-        db_session.query(Partner).filter(Partner.name == example_partner.name).first()
+        db_session.query(Partner)
+        .filter(Partner.name == example_partner.name)
+        .first()
     )
 
-    member_obj = db_session.query(User).filter(User.email == example_user.email).first()
+    member_obj = (
+        db_session.query(User).filter(User.email == example_user.email).first()
+    )
 
-    admin_obj = db_session.query(User).filter(User.email == admin_user.email).first()
+    admin_obj = (
+        db_session.query(User).filter(User.email == admin_user.email).first()
+    )
 
     users.append(member_obj)
     users.append(admin_obj)
 
     for user in users:
-        association_obj = PartnerMember(partner_id=partner_obj.id, user_id=user.id)
+        association_obj = PartnerMember(
+            partner_id=partner_obj.id, user_id=user.id
+        )
         db_session.add(association_obj)
         db_session.commit()
 
@@ -351,7 +372,8 @@ def test_get_incidents_pagination(
     per_page = 2
     page = 1
     res = client.get(
-        f"/api/v1/partners/{example_partner_member.id}/incidents?per_page={per_page}&page={page}",
+        f"/api/v1/partners/{example_partner_member.id}/incidents"
+        + f"?per_page={per_page}&page={page}",
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert res.status_code == 200
@@ -370,7 +392,9 @@ def test_get_incidents_pagination(
     assert data["page"] == page
 
     # Verify the total pages
-    assert data["totalPages"] == len(example_incidents_private_public) // per_page
+    assert (
+        data["totalPages"] == len(example_incidents_private_public) // per_page
+    )
 
     # Verify the total results
     assert data["totalResults"] == len(example_incidents_private_public)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.black]
 line-length = 80
+
+[tool.ruff]
+line-length = 80


### PR DESCRIPTION
Added a route for Epic 3 to get the organization's incidents
 
_Also, I figured out a way to type the ORM models. I imported [ `from __future__ import annotations` ](https://stackoverflow.com/questions/61544854/from-future-import-annotations) at the top of the files to complete the generic with a type instead of a class. Also, to remove the errors when creating a new orm model manually, if you add `def __init__(self, **kwargs): super().__init__(**kwargs),` they magically go away, and you get fully type support._