### PR TITLE
Delete Incidents Route

### DIFF
--- a/backend/database/core.py
+++ b/backend/database/core.py
@@ -20,32 +20,35 @@ from werkzeug.utils import secure_filename
 
 from ..config import TestingConfig
 from ..utils import dev_only
+from typing import TypeVar
 
 db = SQLAlchemy()
+
+T = TypeVar('T')
+
 
 
 class CrudMixin:
     """Mix me into a database model whose CRUD operations you want to expose in
     a convenient manner.
     """
-
-    def create(self, refresh: bool = True):
+    def create(self: T, refresh: bool = True) -> T:
         db.session.add(self)
         db.session.commit()
         if refresh:
             db.session.refresh(self)
         return self
 
-    def delete(self):
+    def delete(self) -> None:
         db.session.delete(self)
         db.session.commit()
 
     @classmethod
-    def get(cls, id: Any, abort_if_null: bool = True):
+    def get(cls: type[T], id: Any, abort_if_null: bool = True) -> Optional[T]:
         obj = db.session.query(cls).get(id)
         if obj is None and abort_if_null:
             abort(404)
-        return obj
+        return obj # type: ignore
 
 
 QUERIES_DIR = os.path.abspath(

--- a/backend/database/core.py
+++ b/backend/database/core.py
@@ -24,14 +24,14 @@ from typing import TypeVar
 
 db = SQLAlchemy()
 
-T = TypeVar('T')
-
+T = TypeVar("T")
 
 
 class CrudMixin:
     """Mix me into a database model whose CRUD operations you want to expose in
     a convenient manner.
     """
+
     def create(self: T, refresh: bool = True) -> T:
         db.session.add(self)
         db.session.commit()
@@ -48,7 +48,7 @@ class CrudMixin:
         obj = db.session.query(cls).get(id)
         if obj is None and abort_if_null:
             abort(404)
-        return obj # type: ignore
+        return obj  # type: ignore
 
 
 QUERIES_DIR = os.path.abspath(

--- a/backend/routes/partners.py
+++ b/backend/routes/partners.py
@@ -327,16 +327,16 @@ def delete_incident(partner_id: int, incident_id: int):
         incident_id (int): The ID of the incident.
 
     Returns:
-        dict: A dictionary with a message indicating the success of the deletion.
+        dict: A dictionary with a message indicating the
+        success of the deletion.
 
     Raises:
         403: If the user does not have permission to delete the incident.
         404: If the partner or incident is not found.
     """
-    jwt_decoded: dict[str, str] = get_jwt() 
+    jwt_decoded: dict[str, str] = get_jwt()
     user_id = jwt_decoded["sub"]
-    
-    
+
     # Check permissions first for security
     permission = PartnerMember.query.filter(  # type: ignore
         PartnerMember.user_id == user_id,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -270,7 +270,7 @@ def partner_admin(db_session, example_partner):
 
 
 @pytest.fixture
-def partner_publisher(db_session, example_partner):
+def partner_publisher(db_session: Any, example_partner: PartnerMember):
     user = User(
         email=contributor_email,
         password=user_manager.hash_password(example_password),

--- a/backend/tests/test_partners.py
+++ b/backend/tests/test_partners.py
@@ -461,30 +461,32 @@ def test_delete_incident(
     # Verify that the incident is deleted
     deleted_incident = Incident.query.get(example_incidents[0].id)
     assert deleted_incident is None
-    
+
+
 def test_delete_incident_no_user_role(
     client: Any,
     access_token: str,
 ):
     """
-    Test that a user without atlest CONTRIBUTOR role can't delete an incident.
+    Test that a user without atlest CONTRIBUTOR role
+    can't delete an incident.
     """
     # Make a request to delete the incident
     res = client.delete(
-        f"/api/v1/partners/{999}"
-        + f"/incidents/{999}",
+        f"/api/v1/partners/{999}" + f"/incidents/{999}",
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert res.status_code == 403
 
-    
+
 def test_delete_incident_bad_partner_id(
     client: Any,
     partner_publisher: User,
     example_incidents: List[Incident],
 ):
     """
-    Test that a partner member can't delete an incident with a invalid partner id.
+    Test that a partner member can't delete an incident
+    with a invalid partner id.
     """
     access_token = res = client.post(
         "api/v1/auth/login",
@@ -496,20 +498,20 @@ def test_delete_incident_bad_partner_id(
 
     # Make a request to delete the incident
     res = client.delete(
-        f"/api/v1/partners/{999}"
-        + f"/incidents/{example_incidents[0].id}",
+        f"/api/v1/partners/{999}" + f"/incidents/{example_incidents[0].id}",
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert res.status_code == 403
-    
-    
+
+
 def test_delete_incident_bad_incident_id(
     client: Any,
     partner_publisher: User,
     example_partner: Partner,
 ):
     """
-    Test that a partner member can't delete an incident with a invalid incident id.
+    Test that a partner member can't delete an incident
+    with a invalid incident id.
     """
     access_token = res = client.post(
         "api/v1/auth/login",
@@ -521,8 +523,7 @@ def test_delete_incident_bad_incident_id(
 
     # Make a request to delete the incident
     res = client.delete(
-        f"/api/v1/partners/{example_partner.id}"
-        + f"/incidents/{999}",
+        f"/api/v1/partners/{example_partner.id}" + f"/incidents/{999}",
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert res.status_code == 404


### PR DESCRIPTION
Simple Route for partners to delete incidents. I also added generics to some of the CRUDMixins for improved type support. 

**IMPORTANT** Merge after https://github.com/codeforboston/police-data-trust/pull/320