### PR TITLE
Epic 2 Foundational UI -- Profile Notifications/No Organizations Views

### DIFF
--- a/frontend/compositions/index.tsx
+++ b/frontend/compositions/index.tsx
@@ -11,6 +11,7 @@ import EditProfileInfo from "./profile-edit"
 import ProfileInfo from "./profile-info"
 import ProfileNav from "./profile-nav"
 import ProfileNotifications from "./profile-notifications/profile-notifications"
+import ProfileOrganizations from "./profile-organizations/profile-organizations"
 import SavedResults from "./profile-saved-tables/saved-results"
 import SavedSearches from "./profile-saved-tables/saved-searches"
 import ProfileType from "./profile-type"
@@ -31,6 +32,7 @@ export {
   ProfileInfo,
   ProfileNav,
   ProfileNotifications,
+  ProfileOrganizations,
   ProfileType,
   RegistrationResponse,
   SavedResults,

--- a/frontend/compositions/index.tsx
+++ b/frontend/compositions/index.tsx
@@ -10,6 +10,7 @@ import PasswordAid from "./password-aid/password-aid"
 import EditProfileInfo from "./profile-edit"
 import ProfileInfo from "./profile-info"
 import ProfileNav from "./profile-nav"
+import ProfileNotifications from "./profile-notifications/profile-notifications"
 import SavedResults from "./profile-saved-tables/saved-results"
 import SavedSearches from "./profile-saved-tables/saved-searches"
 import ProfileType from "./profile-type"
@@ -29,6 +30,7 @@ export {
   PasswordAid,
   ProfileInfo,
   ProfileNav,
+  ProfileNotifications,
   ProfileType,
   RegistrationResponse,
   SavedResults,

--- a/frontend/compositions/profile-nav/index.tsx
+++ b/frontend/compositions/profile-nav/index.tsx
@@ -1,28 +1,24 @@
 import * as React from "react"
-import { ProfileMenu } from "../../models/profile"
+import { ProfileMenu, profileMenuItems } from "../../models/profile"
 import styles from "./profile-nav.module.css"
 
 interface ProfileNavProps {
-  currentItem: ProfileMenu
-  selectNav: Function
+  activePage: ProfileMenu
+  setActivePage: React.Dispatch<React.SetStateAction<ProfileMenu>>
 }
 
-const menuItems = [
-  { item: ProfileMenu.USER_INFO, text: "User Information" },
-  { item: ProfileMenu.PROFILE_TYPE, text: "Profile Type" },
-  { item: ProfileMenu.SAVED_RESULTS, text: "Saved Results" },
-  { item: ProfileMenu.SAVED_SEARCHES, text: "Saved Searches" }
-]
-
-export default function ProfileNav({ currentItem, selectNav }: ProfileNavProps) {
-  const clsName = (itm: string) => (itm === currentItem ? styles.selectedItem : styles.menuItem)
+export default function ProfileNav({ activePage, setActivePage }: ProfileNavProps) {
+  const clsName = (item: string) => (item === activePage ? styles.selectedItem : styles.menuItem)
 
   return (
     <nav className={styles.leftMenu}>
       <ul>
-        {menuItems.map((mnu) => (
-          <li key={mnu.item} onClick={() => selectNav(mnu.item)} className={clsName(mnu.item)}>
-            {mnu.text}
+        {profileMenuItems.map((menu) => (
+          <li
+            key={menu.item}
+            onClick={() => setActivePage(menu.item)}
+            className={clsName(menu.item)}>
+            {menu.text}
           </li>
         ))}
       </ul>

--- a/frontend/compositions/profile-nav/profile-nav.module.css
+++ b/frontend/compositions/profile-nav/profile-nav.module.css
@@ -1,23 +1,19 @@
 .leftMenu {
-  display: flex;
-
-  flex-direction: row;
-  align-items: flex-start;
   font-weight: bold;
-  text-align: left;
-
+  padding: var(--size20) var(--size32);
   border: 1px solid var(--darkBlue);
-  box-sizing: border-box;
   box-shadow: -2px 2px 4px 2px rgba(0, 0, 0, 0.25);
   border-radius: var(--size10);
+  align-self: flex-start;
+}
 
-  margin-left: var(--size10);
-  margin-right: var(--size24);
-  margin-top: var(--size20);
-  width: var(--size192);
+.leftMenu ul {
+  margin: 0;
+  padding: 0;
 
-  line-height: 2.5;
-  height: var(--size200);
+  display: flex;
+  flex-direction: column;
+  gap: var(--size20);
 }
 
 .leftMenu li {

--- a/frontend/compositions/profile-notifications/profile-notifications.module.css
+++ b/frontend/compositions/profile-notifications/profile-notifications.module.css
@@ -1,0 +1,32 @@
+.notificationsContainer {
+  flex: 1;
+}
+
+.headerContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.headerText {
+  font-size: var(--size28);
+  font-weight: bold;
+  color: var(--darkBlue);
+}
+
+.headerCTA {
+  /* Get rid of default margins */
+  margin: 0;
+
+  min-width: max-content;
+  font-size: var(--size16);
+  font-weight: bold;
+}
+
+.actionBtn {
+  /* Define row height */
+  margin: var(--size4) 0;
+
+  width: min-content;
+  height: var(--size32);
+}

--- a/frontend/compositions/profile-notifications/profile-notifications.module.css
+++ b/frontend/compositions/profile-notifications/profile-notifications.module.css
@@ -17,16 +17,5 @@
 .headerCTA {
   /* Get rid of default margins */
   margin: 0;
-
-  min-width: max-content;
-  font-size: var(--size16);
-  font-weight: bold;
-}
-
-.actionBtn {
-  /* Define row height */
-  margin: var(--size4) 0;
-
-  width: min-content;
-  height: var(--size32);
+  font-size: var(--size16) !important;
 }

--- a/frontend/compositions/profile-notifications/profile-notifications.tsx
+++ b/frontend/compositions/profile-notifications/profile-notifications.tsx
@@ -1,6 +1,4 @@
-import { Column } from "react-table"
-import { PrimaryButton } from "../../shared-components"
-import { DataTable } from "../../shared-components/data-table/data-table"
+import { CreateOrganizationBtn, DataTable } from "../../shared-components"
 import styles from "./profile-notifications.module.css"
 
 enum MemberRole {
@@ -26,7 +24,7 @@ export default function ProfileNotifications() {
     <section className={notificationsContainer}>
       <div className={headerContainer}>
         <h1 className={headerText}>Notifications</h1>
-        <PrimaryButton className={headerCTA}>Create Organization</PrimaryButton>
+        <CreateOrganizationBtn btnClassName={headerCTA} />
       </div>
       <DataTable tableName="Notifications" data={notifications} columns={notificationsColumns} />
     </section>

--- a/frontend/compositions/profile-notifications/profile-notifications.tsx
+++ b/frontend/compositions/profile-notifications/profile-notifications.tsx
@@ -1,5 +1,7 @@
+import { CellProps, Column } from "react-table"
 import { CreateOrganizationBtn, DataTable } from "../../shared-components"
 import styles from "./profile-notifications.module.css"
+import ConfirmOrgDialog from "./sub-comps/confirm-org-dialog"
 
 enum MemberRole {
   ADMIN = "Administrator",
@@ -90,12 +92,9 @@ const notificationsColumns: Column<InterimInvitation>[] = [
   },
   {
     Header: "Action",
-    Cell: () => (
-      <PrimaryButton
-        className={styles.actionBtn}
-        onClick={() => console.log("join/leave clicked.")}>
-        Join
-      </PrimaryButton>
-    )
+    Cell: ({ row }: CellProps<InterimInvitation>) => {
+      const organizationName = row.original.organization
+      return <ConfirmOrgDialog organizationName={organizationName} />
+    }
   }
 ]

--- a/frontend/compositions/profile-notifications/profile-notifications.tsx
+++ b/frontend/compositions/profile-notifications/profile-notifications.tsx
@@ -1,0 +1,103 @@
+import { Column } from "react-table"
+import { PrimaryButton } from "../../shared-components"
+import { DataTable } from "../../shared-components/data-table/data-table"
+import styles from "./profile-notifications.module.css"
+
+enum MemberRole {
+  ADMIN = "Administrator",
+  PUBLISHER = "Publisher",
+  MEMBER = "Member",
+  SUBSCRIBER = "Subscriber"
+}
+
+interface InterimInvitation {
+  organization: string
+  role: MemberRole
+  dateInvited: Date
+  status: string
+}
+
+export default function ProfileNotifications() {
+  const { notificationsContainer, headerContainer, headerText, headerCTA } = styles
+
+  // TODO: get user's invitations
+
+  return (
+    <section className={notificationsContainer}>
+      <div className={headerContainer}>
+        <h1 className={headerText}>Notifications</h1>
+        <PrimaryButton className={headerCTA}>Create Organization</PrimaryButton>
+      </div>
+      <DataTable tableName="Notifications" data={notifications} columns={notificationsColumns} />
+    </section>
+  )
+}
+
+const notifications: InterimInvitation[] = [
+  {
+    organization: "Pearson Hardman",
+    role: MemberRole.ADMIN,
+    dateInvited: new Date("8/8/2021"),
+    status: "Invitation"
+  },
+  {
+    organization: "Pearson Hardman Litt",
+    role: MemberRole.ADMIN,
+    dateInvited: new Date("7/30/2021"),
+    status: "Invitation"
+  },
+  {
+    organization: "Zane Specter Litt",
+    role: MemberRole.PUBLISHER,
+    dateInvited: new Date("6/15/2021"),
+    status: "Current Member"
+  },
+  {
+    organization: "Porter Hedges",
+    role: MemberRole.MEMBER,
+    dateInvited: new Date("5/2/2021"),
+    status: "Current Member"
+  }
+]
+
+const notificationsColumns: Column<InterimInvitation>[] = [
+  {
+    Header: "Organization",
+    accessor: "organization",
+    id: "organization"
+  },
+  {
+    Header: "Role",
+    accessor: "role",
+    id: "role"
+  },
+  {
+    Header: "Date Invited",
+    Cell: (props) => (
+      <div>
+        {new Intl.DateTimeFormat("en-US", {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit"
+        }).format(props.cell.value)}
+      </div>
+    ),
+    accessor: "dateInvited",
+    id: "dateInvited"
+  },
+  {
+    Header: "Status",
+    accessor: "status",
+    id: "status"
+  },
+  {
+    Header: "Action",
+    Cell: () => (
+      <PrimaryButton
+        className={styles.actionBtn}
+        onClick={() => console.log("join/leave clicked.")}>
+        Join
+      </PrimaryButton>
+    )
+  }
+]

--- a/frontend/compositions/profile-notifications/sub-comps/confirm-org-dialog.module.css
+++ b/frontend/compositions/profile-notifications/sub-comps/confirm-org-dialog.module.css
@@ -1,0 +1,28 @@
+.actionBtn {
+  /* Define row height */
+  margin: var(--size4) 0;
+
+  width: min-content;
+  height: var(--size32);
+}
+
+.btnContainer {
+  display: flex;
+  flex-direction: row;
+  margin: 0 auto;
+  gap: var(--size16);
+}
+
+.btn {
+  /* RESET MARGINS from PrimaryButton */
+  margin: 0;
+}
+
+.confirmBtn {
+  font-weight: bold;
+}
+
+.notYetBtn {
+  background-color: var(--red);
+  font-weight: bold;
+}

--- a/frontend/compositions/profile-notifications/sub-comps/confirm-org-dialog.tsx
+++ b/frontend/compositions/profile-notifications/sub-comps/confirm-org-dialog.tsx
@@ -1,0 +1,48 @@
+import classNames from "classnames"
+import { PrimaryButton, Dialog as D } from "../../../shared-components"
+import styles from "./confirm-org-dialog.module.css"
+import { useState } from "react"
+
+interface ConfirmOrgDialogProps {
+  organizationName: string
+}
+
+export default function ConfirmOrgDialog({ organizationName }: ConfirmOrgDialogProps) {
+  const [open, setOpen] = useState(false)
+  // TODO: determine if user is joining or leaving
+
+  const handleConfirm = () => {
+    // TODO: Join/Leave organization
+    console.log("Joined or Left Organization: ", organizationName)
+    setOpen(false)
+  }
+
+  const handleNotYet = () => {
+    setOpen(false)
+  }
+
+  return (
+    <D.Root open={open} onOpenChange={setOpen}>
+      <D.Trigger asChild>
+        <PrimaryButton className={styles.actionBtn}>Join</PrimaryButton>
+      </D.Trigger>
+      <D.Content>
+        <D.Header>
+          <D.Title>Are you sure you want to join {organizationName}?</D.Title>
+        </D.Header>
+        <D.Footer className={styles.btnContainer}>
+          <PrimaryButton
+            className={classNames(styles.btn, styles.confirmBtn)}
+            onClick={handleConfirm}>
+            Join
+          </PrimaryButton>
+          <PrimaryButton
+            className={classNames(styles.btn, styles.notYetBtn)}
+            onClick={handleNotYet}>
+            Not Yet
+          </PrimaryButton>
+        </D.Footer>
+      </D.Content>
+    </D.Root>
+  )
+}

--- a/frontend/compositions/profile-organizations/no-organizations/no-organizations.module.css
+++ b/frontend/compositions/profile-organizations/no-organizations/no-organizations.module.css
@@ -4,9 +4,3 @@
   color: var(--darkBlue);
   margin-bottom: var(--size16);
 }
-
-.organizationBtn {
-  font-size: var(--size20);
-  font-weight: bold;
-  min-width: max-content;
-}

--- a/frontend/compositions/profile-organizations/no-organizations/no-organizations.module.css
+++ b/frontend/compositions/profile-organizations/no-organizations/no-organizations.module.css
@@ -1,0 +1,12 @@
+.headerText {
+  font-size: var(--size24);
+  font-weight: bold;
+  color: var(--darkBlue);
+  margin-bottom: var(--size16);
+}
+
+.organizationBtn {
+  font-size: var(--size20);
+  font-weight: bold;
+  min-width: max-content;
+}

--- a/frontend/compositions/profile-organizations/no-organizations/no-organizations.tsx
+++ b/frontend/compositions/profile-organizations/no-organizations/no-organizations.tsx
@@ -1,14 +1,15 @@
-import { Logo, PrimaryButton } from "../../../shared-components"
+import { Logo } from "../../../shared-components"
 import styles from "./no-organizations.module.css"
+import CreateOrganizationBtn from "../../../shared-components/create-organization-btn/create-organization-btn"
 
 export default function NoOrganizations() {
-  const { headerText, organizationBtn } = styles
+  const { headerText } = styles
 
   return (
     <>
       <Logo />
       <h1 className={headerText}>You&apos;re currently Not Part of Any Organizations</h1>
-      <PrimaryButton className={organizationBtn}>Create Organization</PrimaryButton>
+      <CreateOrganizationBtn />
     </>
   )
 }

--- a/frontend/compositions/profile-organizations/no-organizations/no-organizations.tsx
+++ b/frontend/compositions/profile-organizations/no-organizations/no-organizations.tsx
@@ -1,6 +1,5 @@
-import { Logo } from "../../../shared-components"
+import { Logo, CreateOrganizationBtn } from "../../../shared-components"
 import styles from "./no-organizations.module.css"
-import CreateOrganizationBtn from "../../../shared-components/create-organization-btn/create-organization-btn"
 
 export default function NoOrganizations() {
   const { headerText } = styles

--- a/frontend/compositions/profile-organizations/no-organizations/no-organizations.tsx
+++ b/frontend/compositions/profile-organizations/no-organizations/no-organizations.tsx
@@ -1,0 +1,14 @@
+import { Logo, PrimaryButton } from "../../../shared-components"
+import styles from "./no-organizations.module.css"
+
+export default function NoOrganizations() {
+  const { headerText, organizationBtn } = styles
+
+  return (
+    <>
+      <Logo />
+      <h1 className={headerText}>You&apos;re currently Not Part of Any Organizations</h1>
+      <PrimaryButton className={organizationBtn}>Create Organization</PrimaryButton>
+    </>
+  )
+}

--- a/frontend/compositions/profile-organizations/profile-organizations.module.css
+++ b/frontend/compositions/profile-organizations/profile-organizations.module.css
@@ -1,0 +1,9 @@
+.organizationContainer {
+  flex: 1;
+  text-align: center;
+  padding: 0 var(--size192);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/frontend/compositions/profile-organizations/profile-organizations.tsx
+++ b/frontend/compositions/profile-organizations/profile-organizations.tsx
@@ -1,0 +1,20 @@
+import { useAuth } from "../../helpers"
+import NoOrganizations from "./no-organizations/no-organizations"
+import styles from "./profile-organizations.module.css"
+
+export default function ProfileOrganizations() {
+  const { organizationContainer, headerText, organizationBtn } = styles
+  const { user } = useAuth()
+
+  // TODO: Find user's organizations (if any)
+  // API endpoint needed: Given a user, get their partners
+
+  // TODO: Separate UI for:
+  // 2. Existing Organizations
+
+  return (
+    <section className={organizationContainer}>
+      <NoOrganizations />
+    </section>
+  )
+}

--- a/frontend/helpers/hooks/useId.ts
+++ b/frontend/helpers/hooks/useId.ts
@@ -12,8 +12,6 @@ const useId = () => {
     }
   }, [])
 
-  console.log("ID: ", id)
-
   return id
 }
 

--- a/frontend/helpers/hooks/useId.ts
+++ b/frontend/helpers/hooks/useId.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react"
+
+let idCounter = 0
+
+const useId = () => {
+  const [id] = useState(() => `generated-id-${idCounter++}`)
+
+  useEffect(() => {
+    // Reset the counter when the component unmounts
+    return () => {
+      idCounter = 0
+    }
+  }, [])
+
+  console.log("ID: ", id)
+
+  return id
+}
+
+export default useId

--- a/frontend/models/profile.tsx
+++ b/frontend/models/profile.tsx
@@ -5,7 +5,9 @@ export enum ProfileMenu {
   USER_INFO = "info",
   PROFILE_TYPE = "type",
   SAVED_SEARCHES = "searches",
-  SAVED_RESULTS = "results"
+  SAVED_RESULTS = "results",
+  NOTIFICATIONS = "notifications",
+  ORGANIZATIONS = "organizations"
 }
 
 interface MenuText {
@@ -17,7 +19,9 @@ export const profileMenuItems: MenuText[] = [
   { item: ProfileMenu.USER_INFO, text: "User Information" },
   { item: ProfileMenu.PROFILE_TYPE, text: "Profile Type" },
   { item: ProfileMenu.SAVED_RESULTS, text: "Saved Results" },
-  { item: ProfileMenu.SAVED_SEARCHES, text: "Saved Searches" }
+  { item: ProfileMenu.SAVED_SEARCHES, text: "Saved Searches" },
+  { item: ProfileMenu.NOTIFICATIONS, text: "Notifications" },
+  { item: ProfileMenu.ORGANIZATIONS, text: "My Organizations" }
 ]
 
 // props for profile menu content

--- a/frontend/models/profile.tsx
+++ b/frontend/models/profile.tsx
@@ -13,26 +13,12 @@ interface MenuText {
   text: string
 }
 
-export const menuContent: {
-  [key in ProfileMenu]: MenuText
-} = {
-  [ProfileMenu.USER_INFO]: {
-    item: ProfileMenu.USER_INFO,
-    text: "User Information"
-  },
-  [ProfileMenu.PROFILE_TYPE]: {
-    item: ProfileMenu.PROFILE_TYPE,
-    text: "Profile Type"
-  },
-  [ProfileMenu.SAVED_RESULTS]: {
-    item: ProfileMenu.SAVED_RESULTS,
-    text: "Saved Results"
-  },
-  [ProfileMenu.SAVED_SEARCHES]: {
-    item: ProfileMenu.SAVED_SEARCHES,
-    text: "Saved Searches"
-  }
-}
+export const profileMenuItems: MenuText[] = [
+  { item: ProfileMenu.USER_INFO, text: "User Information" },
+  { item: ProfileMenu.PROFILE_TYPE, text: "Profile Type" },
+  { item: ProfileMenu.SAVED_RESULTS, text: "Saved Results" },
+  { item: ProfileMenu.SAVED_SEARCHES, text: "Saved Searches" }
+]
 
 // props for profile menu content
 export interface UserProfileProps {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@googlemaps/js-api-loader": "^1.14.3",
+        "@hookform/resolvers": "^3.3.4",
+        "@radix-ui/react-dialog": "^1.0.5",
+        "@radix-ui/react-label": "^2.0.2",
+        "@radix-ui/react-select": "^2.0.0",
+        "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-toggle-group": "^1.0.4",
         "axios": "^0.21.1",
         "classnames": "^2.3.1",
         "d3": "^7.0.0",
@@ -16,11 +22,12 @@
         "react": "^17.0.2",
         "react-accessible-dropdown-menu-hook": "^3.1.0",
         "react-dom": "^17.0.2",
-        "react-hook-form": "^7.15.0",
+        "react-hook-form": "^7.50.1",
         "react-responsive": "^9.0.0-beta.4",
         "react-tooltip": "^5.25.1",
         "topojson-client": "^3.1.0",
-        "topojson-simplify": "^3.0.3"
+        "topojson-simplify": "^3.0.3",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@babel/core": "^7.15.5",
@@ -2711,20 +2718,32 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.3.tgz",
-      "integrity": "sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.0"
+        "@floating-ui/utils": "^0.2.1"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.4.tgz",
-      "integrity": "sha512-jByEsHIY+eEdCjnTVu+E3ephzTOzkQ8hgUfGwos+bg7NlH33Zc5uO+QHz1mrQUOgIKKDD1RtS201P9NvAfq3XQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.1.tgz",
+      "integrity": "sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==",
       "dependencies": {
-        "@floating-ui/core": "^1.5.3",
-        "@floating-ui/utils": "^0.2.0"
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@floating-ui/utils": {
@@ -2842,6 +2861,14 @@
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
       "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.4.tgz",
+      "integrity": "sha512-o5cgpGOuJYrd+iMKvkttOclgwRW86EsWJZZRC23prf0uU2i48Htq4PuT73AVb9ionFyZrwYEITuOFGF+BydEtQ==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -5199,6 +5226,670 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
+      "integrity": "sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz",
+      "integrity": "sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+      "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
+      "integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
+      "integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-escape-keydown": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
+      "integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz",
+      "integrity": "sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.0.2.tgz",
+      "integrity": "sha512-N5ehvlM7qoTLx7nWPodsPYPgMzA5WM8zZChQg8nyFJKnDO5WHdba1vv5/H6IO5LtJMfD2Q3wh1qHFGNtK0w3bQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.1.3.tgz",
+      "integrity": "sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-rect": "1.0.1",
+        "@radix-ui/react-use-size": "1.0.1",
+        "@radix-ui/rect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
+      "integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
+      "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.0.0.tgz",
+      "integrity": "sha512-RH5b7af4oHtkcHS7pG6Sgv5rk5Wxa7XI8W5gvB1N/yiuDGZxko1ynvOiVhFM7Cis2A8zxF9bTOUVbRDzPepe6w==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.0.3.tgz",
+      "integrity": "sha512-Pkqg3+Bc98ftZGsl60CLANXQBBQ4W3mTFS9EJvNxKMZ7magklKV69/id1mlAlOFDDfHvlCms0fx8fA4CMKDJHg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.0.4.tgz",
+      "integrity": "sha512-Uaj/M/cMyiyT9Bx6fOZO0SAG4Cls0GptBWiBmBxofmDbNVnYYoyRWj/2M/6VCi/7qcXFWnHhRUfdfZFvvkuu8A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-toggle": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
+      "integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz",
+      "integrity": "sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz",
+      "integrity": "sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/rect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz",
+      "integrity": "sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz",
+      "integrity": "sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.0.1.tgz",
+      "integrity": "sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@reach/router": {
@@ -11554,7 +12245,7 @@
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -11575,7 +12266,7 @@
       "version": "17.0.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.27.tgz",
       "integrity": "sha512-zgiJwtsggVGtr53MndV7jfiUESTqrbxOcBvwfe6KS/9bzaVPCTDieTWnFNecVNx6EAaapg5xsLLWFfHHR437AA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -11586,7 +12277,7 @@
       "version": "17.0.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
       "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -11622,7 +12313,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.1",
@@ -12668,6 +13359,17 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/aria-query": {
@@ -15931,7 +16633,7 @@
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
       "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/cyclist": {
       "version": "1.0.1",
@@ -16569,6 +17271,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/detect-port-alt": {
       "version": "1.1.6",
@@ -19636,6 +20343,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/get-orientation": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/get-orientation/-/get-orientation-1.1.2.tgz",
@@ -20873,7 +21588,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -29879,15 +30593,18 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.17.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.17.1.tgz",
-      "integrity": "sha512-9nQ+qKFHFpnWzQHdDh6F4Egxa8iJkue1KU921F8qqeyUVbPPjgQZDXaQyNHABEYjRh0ndjTI24GDA+lwm2lQdg==",
+      "version": "7.50.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.1.tgz",
+      "integrity": "sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17"
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-inspector": {
@@ -29952,6 +30669,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.3",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+      "dependencies": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-responsive": {
       "version": "9.0.0-beta.4",
       "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.0-beta.4.tgz",
@@ -29992,6 +30754,28 @@
         "invariant": "^2.2.4",
         "shallowequal": "^1.1.0",
         "throttle-debounce": "^3.0.1"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-syntax-highlighter": {
@@ -32976,8 +33760,7 @@
     "node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -33559,6 +34342,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.1.tgz",
+      "integrity": "sha512-Lg4Vx1XZQauB42Hw3kK7JM6yjVjgFmFC5/Ab797s79aARomD2nEErc4mCgM8EZrARLmmbWpi5DGCadmK50DcAQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-composed-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
@@ -33613,6 +34416,27 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-subscription": {
@@ -34932,6 +35756,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {
@@ -36842,20 +37674,28 @@
       }
     },
     "@floating-ui/core": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.3.tgz",
-      "integrity": "sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
       "requires": {
-        "@floating-ui/utils": "^0.2.0"
+        "@floating-ui/utils": "^0.2.1"
       }
     },
     "@floating-ui/dom": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.4.tgz",
-      "integrity": "sha512-jByEsHIY+eEdCjnTVu+E3ephzTOzkQ8hgUfGwos+bg7NlH33Zc5uO+QHz1mrQUOgIKKDD1RtS201P9NvAfq3XQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.1.tgz",
+      "integrity": "sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==",
       "requires": {
-        "@floating-ui/core": "^1.5.3",
-        "@floating-ui/utils": "^0.2.0"
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "requires": {
+        "@floating-ui/dom": "^1.6.1"
       }
     },
     "@floating-ui/utils": {
@@ -36949,6 +37789,12 @@
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
       "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+    },
+    "@hookform/resolvers": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.4.tgz",
+      "integrity": "sha512-o5cgpGOuJYrd+iMKvkttOclgwRW86EsWJZZRC23prf0uU2i48Htq4PuT73AVb9ionFyZrwYEITuOFGF+BydEtQ==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -38752,6 +39598,343 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
       "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==",
       "dev": true
+    },
+    "@radix-ui/number": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz",
+      "integrity": "sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-arrow": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz",
+      "integrity": "sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      }
+    },
+    "@radix-ui/react-collection": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+      "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
+      }
+    },
+    "@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-dialog": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
+      "integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      }
+    },
+    "@radix-ui/react-direction": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-dismissable-layer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz",
+      "integrity": "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-escape-keydown": "1.0.3"
+      }
+    },
+    "@radix-ui/react-focus-guards": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
+      "integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-focus-scope": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz",
+      "integrity": "sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      }
+    },
+    "@radix-ui/react-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      }
+    },
+    "@radix-ui/react-label": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.0.2.tgz",
+      "integrity": "sha512-N5ehvlM7qoTLx7nWPodsPYPgMzA5WM8zZChQg8nyFJKnDO5WHdba1vv5/H6IO5LtJMfD2Q3wh1qHFGNtK0w3bQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      }
+    },
+    "@radix-ui/react-popper": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.1.3.tgz",
+      "integrity": "sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-rect": "1.0.1",
+        "@radix-ui/react-use-size": "1.0.1",
+        "@radix-ui/rect": "1.0.1"
+      }
+    },
+    "@radix-ui/react-portal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz",
+      "integrity": "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      }
+    },
+    "@radix-ui/react-presence": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      }
+    },
+    "@radix-ui/react-primitive": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.2"
+      }
+    },
+    "@radix-ui/react-roving-focus": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
+      "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      }
+    },
+    "@radix-ui/react-select": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.0.0.tgz",
+      "integrity": "sha512-RH5b7af4oHtkcHS7pG6Sgv5rk5Wxa7XI8W5gvB1N/yiuDGZxko1ynvOiVhFM7Cis2A8zxF9bTOUVbRDzPepe6w==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      }
+    },
+    "@radix-ui/react-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
+      }
+    },
+    "@radix-ui/react-toggle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.0.3.tgz",
+      "integrity": "sha512-Pkqg3+Bc98ftZGsl60CLANXQBBQ4W3mTFS9EJvNxKMZ7magklKV69/id1mlAlOFDDfHvlCms0fx8fA4CMKDJHg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      }
+    },
+    "@radix-ui/react-toggle-group": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.0.4.tgz",
+      "integrity": "sha512-Uaj/M/cMyiyT9Bx6fOZO0SAG4Cls0GptBWiBmBxofmDbNVnYYoyRWj/2M/6VCi/7qcXFWnHhRUfdfZFvvkuu8A==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-toggle": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      }
+    },
+    "@radix-ui/react-use-callback-ref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-use-controllable-state": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      }
+    },
+    "@radix-ui/react-use-escape-keydown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
+      "integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.1"
+      }
+    },
+    "@radix-ui/react-use-layout-effect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-use-previous": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz",
+      "integrity": "sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@radix-ui/react-use-rect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz",
+      "integrity": "sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/rect": "1.0.1"
+      }
+    },
+    "@radix-ui/react-use-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz",
+      "integrity": "sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
+      }
+    },
+    "@radix-ui/react-visually-hidden": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz",
+      "integrity": "sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      }
+    },
+    "@radix-ui/rect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.0.1.tgz",
+      "integrity": "sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
     },
     "@reach/router": {
       "version": "1.3.4",
@@ -43728,7 +44911,7 @@
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
       "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "dev": true
+      "devOptional": true
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -43749,7 +44932,7 @@
       "version": "17.0.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.27.tgz",
       "integrity": "sha512-zgiJwtsggVGtr53MndV7jfiUESTqrbxOcBvwfe6KS/9bzaVPCTDieTWnFNecVNx6EAaapg5xsLLWFfHHR437AA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -43760,7 +44943,7 @@
       "version": "17.0.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz",
       "integrity": "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/react": "*"
       }
@@ -43796,7 +44979,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "devOptional": true
     },
     "@types/set-cookie-parser": {
       "version": "2.4.1",
@@ -44694,6 +45877,14 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+      "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+      "requires": {
+        "tslib": "^2.0.0"
       }
     },
     "aria-query": {
@@ -47271,7 +48462,7 @@
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
       "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==",
-      "dev": true
+      "devOptional": true
     },
     "cyclist": {
       "version": "1.0.1",
@@ -47754,6 +48945,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "detect-port-alt": {
       "version": "1.1.6",
@@ -50183,6 +51379,11 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
+    },
     "get-orientation": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/get-orientation/-/get-orientation-1.1.2.tgz",
@@ -51124,7 +52325,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -58041,9 +59241,9 @@
       }
     },
     "react-hook-form": {
-      "version": "7.17.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.17.1.tgz",
-      "integrity": "sha512-9nQ+qKFHFpnWzQHdDh6F4Egxa8iJkue1KU921F8qqeyUVbPPjgQZDXaQyNHABEYjRh0ndjTI24GDA+lwm2lQdg==",
+      "version": "7.50.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.1.tgz",
+      "integrity": "sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ==",
       "requires": {}
     },
     "react-inspector": {
@@ -58094,6 +59294,27 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
+    "react-remove-scroll": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+      "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+      "requires": {
+        "react-remove-scroll-bar": "^2.3.3",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      }
+    },
+    "react-remove-scroll-bar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+      "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+      "requires": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      }
+    },
     "react-responsive": {
       "version": "9.0.0-beta.4",
       "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.0-beta.4.tgz",
@@ -58125,6 +59346,16 @@
         "invariant": "^2.2.4",
         "shallowequal": "^1.1.0",
         "throttle-debounce": "^3.0.1"
+      }
+    },
+    "react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "requires": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
       }
     },
     "react-syntax-highlighter": {
@@ -60455,8 +61686,7 @@
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -60875,6 +62105,14 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-callback-ref": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.1.tgz",
+      "integrity": "sha512-Lg4Vx1XZQauB42Hw3kK7JM6yjVjgFmFC5/Ab797s79aARomD2nEErc4mCgM8EZrARLmmbWpi5DGCadmK50DcAQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "use-composed-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
@@ -60907,6 +62145,15 @@
       "dev": true,
       "requires": {
         "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
       }
     },
     "use-subscription": {
@@ -61960,6 +63207,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
     },
     "zwitch": {
       "version": "1.0.5",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "react": "^17.0.2",
         "react-accessible-dropdown-menu-hook": "^3.1.0",
         "react-dom": "^17.0.2",
-        "react-hook-form": "^7.50.1",
+        "react-hook-form": "^7.25.0",
         "react-responsive": "^9.0.0-beta.4",
         "react-tooltip": "^5.25.1",
         "topojson-client": "^3.1.0",
@@ -30593,9 +30593,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.50.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.1.tgz",
-      "integrity": "sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.25.0.tgz",
+      "integrity": "sha512-MyF4YXegIT/vfyZloTm98mpJwLUPfULdX37yPzXeijT1hePCkV8DN1IAnEufxgtqCpc7aFGRinegQwisUGZCnA==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -30604,7 +30604,7 @@
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18"
+        "react": "^16.8.0 || ^17"
       }
     },
     "node_modules/react-inspector": {
@@ -59241,9 +59241,9 @@
       }
     },
     "react-hook-form": {
-      "version": "7.50.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.1.tgz",
-      "integrity": "sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.25.0.tgz",
+      "integrity": "sha512-MyF4YXegIT/vfyZloTm98mpJwLUPfULdX37yPzXeijT1hePCkV8DN1IAnEufxgtqCpc7aFGRinegQwisUGZCnA==",
       "requires": {}
     },
     "react-inspector": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,12 @@
   },
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.14.3",
+    "@hookform/resolvers": "^3.3.4",
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-select": "^2.0.0",
+    "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-toggle-group": "^1.0.4",
     "axios": "^0.21.1",
     "classnames": "^2.3.1",
     "d3": "^7.0.0",
@@ -36,11 +42,12 @@
     "react": "^17.0.2",
     "react-accessible-dropdown-menu-hook": "^3.1.0",
     "react-dom": "^17.0.2",
-    "react-hook-form": "^7.15.0",
+    "react-hook-form": "^7.50.1",
     "react-responsive": "^9.0.0-beta.4",
     "react-tooltip": "^5.25.1",
     "topojson-client": "^3.1.0",
-    "topojson-simplify": "^3.0.3"
+    "topojson-simplify": "^3.0.3",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "react": "^17.0.2",
     "react-accessible-dropdown-menu-hook": "^3.1.0",
     "react-dom": "^17.0.2",
-    "react-hook-form": "^7.50.1",
+    "react-hook-form": "^7.25.0",
     "react-responsive": "^9.0.0-beta.4",
     "react-tooltip": "^5.25.1",
     "topojson-client": "^3.1.0",

--- a/frontend/pages/profile/index.tsx
+++ b/frontend/pages/profile/index.tsx
@@ -2,6 +2,8 @@ import * as React from "react"
 import {
   ProfileInfo,
   ProfileNav,
+  ProfileNotifications,
+  ProfileOrganizations,
   ProfileType,
   SavedResults,
   SavedSearches
@@ -24,6 +26,10 @@ export default requireAuth(function Profile() {
         return SavedResults
       case ProfileMenu.SAVED_SEARCHES:
         return SavedSearches
+      case ProfileMenu.NOTIFICATIONS:
+        return ProfileNotifications
+      case ProfileMenu.ORGANIZATIONS:
+        return ProfileOrganizations
       default:
         throw new Error("Must be a key in 'ProfileMenu' enum - unexpected default case!")
     }

--- a/frontend/pages/profile/index.tsx
+++ b/frontend/pages/profile/index.tsx
@@ -1,31 +1,39 @@
 import * as React from "react"
-import { Layout } from "../../shared-components"
-import { ProfileMenu } from "../../models/profile"
-import { requireAuth } from "../../helpers"
 import {
-  DashboardHeader,
   ProfileInfo,
   ProfileNav,
   ProfileType,
-  SavedSearches,
-  SavedResults
+  SavedResults,
+  SavedSearches
 } from "../../compositions"
+import { requireAuth } from "../../helpers"
+import { ProfileMenu } from "../../models/profile"
+import { Layout } from "../../shared-components"
 import styles from "./profile.module.css"
-// import { useAuth, requireAuth } from "../../helpers"
 
 export default requireAuth(function Profile() {
-  const [nav, setNav] = React.useState(ProfileMenu.USER_INFO)
+  const [activePage, setActivePage] = React.useState(ProfileMenu.USER_INFO)
+
+  const ActivePageComp = (function (menuItem: ProfileMenu) {
+    switch (menuItem) {
+      case ProfileMenu.USER_INFO:
+        return ProfileInfo
+      case ProfileMenu.PROFILE_TYPE:
+        return ProfileType
+      case ProfileMenu.SAVED_RESULTS:
+        return SavedResults
+      case ProfileMenu.SAVED_SEARCHES:
+        return SavedSearches
+      default:
+        throw new Error("Must be a key in 'ProfileMenu' enum - unexpected default case!")
+    }
+  })(activePage)
 
   return (
     <Layout>
       <div className={styles.profileWrapper}>
-        <ProfileNav currentItem={nav} selectNav={setNav} />
-
-        {/* TODO: this looks awful */}
-        {nav === ProfileMenu.USER_INFO && <ProfileInfo />}
-        {nav === ProfileMenu.PROFILE_TYPE && <ProfileType />}
-        {nav === ProfileMenu.SAVED_RESULTS && <SavedResults />}
-        {nav === ProfileMenu.SAVED_SEARCHES && <SavedSearches />}
+        <ProfileNav activePage={activePage} setActivePage={setActivePage} />
+        <ActivePageComp />
       </div>
     </Layout>
   )

--- a/frontend/pages/profile/profile.module.css
+++ b/frontend/pages/profile/profile.module.css
@@ -1,4 +1,5 @@
 .profileWrapper {
+  margin: 0 var(--size100);
   margin-top: var(--size32);
   display: flex;
   flex-wrap: wrap;

--- a/frontend/pages/profile/profile.module.css
+++ b/frontend/pages/profile/profile.module.css
@@ -1,14 +1,8 @@
 .profileWrapper {
-  width: 80%;
-  z-index: -10000;
-  margin-top: 2rem;
-  margin-left: 10%;
+  margin-top: var(--size32);
   display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-}
-
-.rightContent {
-  display: inline-block;
-  text-align: left;
+  flex-wrap: wrap;
+  gap: var(--size12);
+  justify-content: center;
+  align-items: center;
 }

--- a/frontend/shared-components/create-organization-btn/create-organization-btn.module.css
+++ b/frontend/shared-components/create-organization-btn/create-organization-btn.module.css
@@ -1,0 +1,5 @@
+.triggerBtn {
+  font-size: var(--size20);
+  font-weight: bold;
+  min-width: max-content;
+}

--- a/frontend/shared-components/create-organization-btn/create-organization-btn.tsx
+++ b/frontend/shared-components/create-organization-btn/create-organization-btn.tsx
@@ -1,0 +1,29 @@
+import classNames from "classnames"
+import { Dialog as D, PrimaryButton } from "../../shared-components"
+import styles from "./create-organization-btn.module.css"
+import CreateOrganizationForm from "./sub-comps/create-organization-form"
+
+interface CreateOrganizationBtnProps {
+  btnClassName?: string
+}
+
+export default function CreateOrganizationBtn({ btnClassName }: CreateOrganizationBtnProps) {
+  const { triggerBtn } = styles
+
+  return (
+    <D.Root>
+      <D.Trigger asChild>
+        <PrimaryButton className={classNames(triggerBtn, btnClassName)}>
+          Create Organization
+        </PrimaryButton>
+      </D.Trigger>
+      <D.Content>
+        <D.Header>
+          <D.Title>Create Organization</D.Title>
+          <D.Description>Create an organization if you don&apos;t already have one.</D.Description>
+        </D.Header>
+        <CreateOrganizationForm />
+      </D.Content>
+    </D.Root>
+  )
+}

--- a/frontend/shared-components/create-organization-btn/sub-comps/create-organization-form.module.css
+++ b/frontend/shared-components/create-organization-btn/sub-comps/create-organization-form.module.css
@@ -3,3 +3,8 @@
   font-weight: bold;
   min-width: max-content;
 }
+
+.orgExists {
+  text-align: center;
+  font-size: var(--size20);
+}

--- a/frontend/shared-components/create-organization-btn/sub-comps/create-organization-form.module.css
+++ b/frontend/shared-components/create-organization-btn/sub-comps/create-organization-form.module.css
@@ -1,0 +1,5 @@
+.organizationCTA {
+  font-size: var(--size16);
+  font-weight: bold;
+  min-width: max-content;
+}

--- a/frontend/shared-components/create-organization-btn/sub-comps/create-organization-form.tsx
+++ b/frontend/shared-components/create-organization-btn/sub-comps/create-organization-form.tsx
@@ -1,0 +1,88 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useState } from "react"
+import { FieldValues, useForm } from "react-hook-form"
+import { z } from "zod"
+import { Dialog as D, Form as F, Input, PrimaryButton } from "../../../shared-components"
+import styles from "./create-organization-form.module.css"
+import SelectOrg from "./select-org"
+import YesNoToggle from "./yes-no-toggle"
+
+type CreateOrganizationSchema = z.infer<typeof createOrganizationSchema>
+const createOrganizationSchema = z.object({
+  organizationName: z.string().min(1, "Organization Name is required."),
+  existingOrg: z.string(),
+  orgExists: z.enum(["YES", "NO"])
+})
+
+export default function CreateOrganizationForm() {
+  const { organizationCTA } = styles
+
+  const formMethods = useForm<CreateOrganizationSchema>({
+    resolver: zodResolver(createOrganizationSchema),
+    defaultValues: {
+      organizationName: "",
+      existingOrg: "",
+      orgExists: "NO"
+    }
+  })
+  const [formCanSubmit, setFormCanSubmit] = useState(true)
+
+  const onSubmit = (values: FieldValues) => {
+    if (values.orgExists === "YES") {
+      setFormCanSubmit(false)
+    } else {
+      console.log("values: ", values)
+    }
+  }
+
+  if (!formCanSubmit) {
+    return <p>Org already exists! For admission, please contact: org@email.com</p>
+  }
+
+  return (
+    <F.Root formMethods={formMethods} onSubmit={formMethods.handleSubmit(onSubmit)}>
+      <F.Field
+        control={formMethods.control}
+        name="organizationName"
+        render={({ field }) => (
+          <F.Item>
+            <F.Label>Name of Organization</F.Label>
+            <F.Control>
+              <Input type="text" {...field} />
+            </F.Control>
+            <F.Message />
+          </F.Item>
+        )}
+      />
+      <F.Field
+        control={formMethods.control}
+        name="existingOrg"
+        render={({ field }) => (
+          <F.Item>
+            <F.Label>Is your organization one of these?</F.Label>
+            <F.Control>
+              <SelectOrg value={field.value} onChange={field.onChange} />
+            </F.Control>
+            <F.Message />
+          </F.Item>
+        )}
+      />
+      <F.Field
+        control={formMethods.control}
+        name="orgExists"
+        render={({ field }) => (
+          <F.Item>
+            <F.Control>
+              <YesNoToggle value={field.value} onChange={field.onChange} />
+            </F.Control>
+          </F.Item>
+        )}
+      />
+      <D.Footer>
+        <PrimaryButton type="submit" className={organizationCTA}>
+          Create Organization
+        </PrimaryButton>
+      </D.Footer>
+    </F.Root>
+  )
+}

--- a/frontend/shared-components/create-organization-btn/sub-comps/create-organization-form.tsx
+++ b/frontend/shared-components/create-organization-btn/sub-comps/create-organization-form.tsx
@@ -15,7 +15,7 @@ const createOrganizationSchema = z.object({
 })
 
 export default function CreateOrganizationForm() {
-  const { organizationCTA } = styles
+  const { organizationCTA, orgExists } = styles
 
   const formMethods = useForm<CreateOrganizationSchema>({
     resolver: zodResolver(createOrganizationSchema),
@@ -36,7 +36,11 @@ export default function CreateOrganizationForm() {
   }
 
   if (!formCanSubmit) {
-    return <p>Org already exists! For admission, please contact: org@email.com</p>
+    return (
+      <p className={orgExists}>
+        The organization already exists! For admission, please contact: org@email.com
+      </p>
+    )
   }
 
   return (

--- a/frontend/shared-components/create-organization-btn/sub-comps/select-org.tsx
+++ b/frontend/shared-components/create-organization-btn/sub-comps/select-org.tsx
@@ -1,0 +1,21 @@
+import { Select as S } from "../../../shared-components"
+
+interface SelectOrgProps {
+  value: string
+  onChange(...event: any[]): void
+}
+
+export default function SelectOrg({ value, onChange }: SelectOrgProps) {
+  return (
+    <S.Root value={value} onValueChange={onChange}>
+      <S.Trigger>
+        <S.Value placeholder="Pick an organization if it's yours..." />
+      </S.Trigger>
+      <S.Content>
+        <S.Item value="organization1">Organization1</S.Item>
+        <S.Item value="organization2">Organization2</S.Item>
+        <S.Item value="organization3">Organization3</S.Item>
+      </S.Content>
+    </S.Root>
+  )
+}

--- a/frontend/shared-components/create-organization-btn/sub-comps/yes-no-toggle.module.css
+++ b/frontend/shared-components/create-organization-btn/sub-comps/yes-no-toggle.module.css
@@ -1,0 +1,20 @@
+.root {
+  display: flex;
+  gap: var(--size4);
+  margin-top: var(--size12);
+}
+
+.item {
+  border: none;
+  background-color: inherit;
+  font-size: var(--size16);
+  color: var(--lightBlue);
+  cursor: pointer;
+}
+
+.selected {
+  font-weight: bold;
+  text-decoration: underline;
+  color: var(--darkBlue);
+  cursor: default;
+}

--- a/frontend/shared-components/create-organization-btn/sub-comps/yes-no-toggle.tsx
+++ b/frontend/shared-components/create-organization-btn/sub-comps/yes-no-toggle.tsx
@@ -1,0 +1,23 @@
+import * as TG from "@radix-ui/react-toggle-group"
+import classNames from "classnames"
+import styles from "./yes-no-toggle.module.css"
+
+interface YesNoToggleProps {
+  value: "YES" | "NO"
+  onChange(...event: any[]): void
+}
+
+export default function YesNoToggle({ value, onChange }: YesNoToggleProps) {
+  return (
+    <TG.Root type="single" value={value} onValueChange={onChange} className={styles.root}>
+      <TG.Item
+        value={"YES"}
+        className={classNames(styles.item, value === "YES" && styles.selected)}>
+        Yes
+      </TG.Item>
+      <TG.Item value={"NO"} className={classNames(styles.item, value === "NO" && styles.selected)}>
+        No
+      </TG.Item>
+    </TG.Root>
+  )
+}

--- a/frontend/shared-components/data-table/data-table.tsx
+++ b/frontend/shared-components/data-table/data-table.tsx
@@ -1,20 +1,18 @@
 import { faArrowDown, faArrowUp } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import React, { useState } from "react"
-import { Column, defaultColumn, useFilters, usePagination, useSortBy, useTable } from "react-table"
-import { Incident, Officer } from "../../helpers/api/api"
-import { SavedResultsType, SavedSearchType } from "../../models"
-import { EditButton, PageNavigator } from "./data-table-subcomps"
+import { Column, useFilters, usePagination, useSortBy, useTable } from "react-table"
+import { PageNavigator } from "./data-table-subcomps"
 import styles from "./data-table.module.css"
 
-interface DataTableProps {
+interface DataTableProps<T extends object> {
   tableName: string
-  columns: Column<any>[]
-  data: Incident[] | SavedSearchType[] | SavedResultsType[] | Officer[] | undefined
+  columns: Column<T>[]
+  data: T[] | undefined
 }
 
-export function DataTable(props: DataTableProps) {
-  const { tableName, data, columns } = props
+export function DataTable<T extends object>(props: DataTableProps<T>) {
+  const { data, columns } = props
   const { dataTable, dataHeader, dataRows } = styles
 
   const [editMode, setEditMode] = useState(false)
@@ -40,7 +38,7 @@ export function DataTable(props: DataTableProps) {
     previousPage,
     setPageSize,
     state: { pageIndex, pageSize }
-  } = useTable(
+  } = useTable<T>(
     {
       columns,
       data,

--- a/frontend/shared-components/dialog/dialog.module.css
+++ b/frontend/shared-components/dialog/dialog.module.css
@@ -1,0 +1,111 @@
+.dialogOverlay {
+  position: fixed;
+  inset: 0px;
+  z-index: 50;
+  background-color: rgba(0, 0, 0, 0.7);
+  cursor: pointer;
+  transition: opacity 100ms ease-in-out;
+}
+
+.dialogOverlay[data-state="open"] {
+  animation: fadeIn 100ms ease-in-out forwards;
+}
+
+.dialogOverlay[data-state="closed"] {
+  animation: fadeOut 100ms ease-in-out;
+}
+
+.dialogContent {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  z-index: 50;
+  display: grid;
+  width: 100%;
+  max-width: 32rem;
+  transform: translate(-50%, -50%);
+  gap: var(--size16);
+  background: var(--white);
+  padding: var(--size24);
+  border: 3px solid var(--darkBlue);
+  border-radius: var(--size4);
+  box-shadow: var(--boxShadow);
+  transition-duration: 100ms;
+}
+
+.dialogContent[data-state="open"] {
+  animation: fadeIn 100ms ease-in-out forwards;
+}
+
+.dialogContent[data-state="close"] {
+  animation: fadeOut 100ms ease-in-out forwards;
+}
+
+.dialogClose {
+  position: absolute;
+  right: var(--size16);
+  top: var(--size16);
+  border: none;
+  background-color: inherit;
+  transition: scale 100ms ease-in-out;
+}
+
+.dialogClose:hover {
+  cursor: pointer;
+  scale: 1.2;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  margin-top: 1.5rem;
+  text-align: center;
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+}
+
+.title {
+  font-size: var(--size28);
+  font-weight: 600;
+  line-height: none;
+  letter-spacing: -0.025em;
+}
+
+.description {
+  font-weight: var(--size16);
+  opacity: 0.7;
+}
+
+/* 400px */
+@media screen and (max-width: 25em) {
+  .header {
+    text-align: left;
+  }
+
+  .footer {
+    flex-direction: row;
+    justify-content: end;
+    margin-left: var(--size8);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}

--- a/frontend/shared-components/dialog/dialog.tsx
+++ b/frontend/shared-components/dialog/dialog.tsx
@@ -1,0 +1,122 @@
+import * as React from "react"
+import * as RadixDialog from "@radix-ui/react-dialog"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faWindowClose } from "@fortawesome/free-solid-svg-icons"
+import classNames from "classnames"
+import styles from "./dialog.module.css"
+
+/**
+ * The base component for creating dialogs. Manages dialog state (open/closed) and contains all parts of a dialog.
+ * @param {RadixDialog.DialogProps} props - Documentation: {@link https://www.radix-ui.com/primitives/docs/components/dialog#root}
+ */
+const Root = RadixDialog.Root
+
+/**
+ * An interactive element that triggers the opening of the dialog.
+ * @param {RadixDialog.DialogTriggerProps} props - Documentation: {@link https://www.radix-ui.com/primitives/docs/components/dialog#trigger}
+ */
+const Trigger = RadixDialog.Trigger
+
+/**
+ * Creates a portal into `document.body` for the dialog overlay and content.
+ * @param {RadixDialog.DialogPortalProps} props - Documentation: {@link https://www.radix-ui.com/primitives/docs/components/dialog#portal}
+ */
+const Portal = RadixDialog.Portal
+
+/**
+ * Button for closing the dialog.
+ * @param {RadixDialog.DialogCloseProps} props - Documentation: {@link https://www.radix-ui.com/primitives/docs/components/dialog#close}
+ */
+const Close = RadixDialog.Close
+
+/**
+ * A semi-transparent overlay that covers the screen when the dialog is open.
+ * Adds default styling and forwards an optional `ref`.
+ * @param {RadixDialog.DialogOverlayProps} props - Documentation: {@link https://www.radix-ui.com/primitives/docs/components/dialog#overlay}
+ */
+const Overlay = React.forwardRef<
+  React.ElementRef<typeof RadixDialog.Overlay>,
+  React.ComponentPropsWithoutRef<typeof RadixDialog.Overlay>
+>(({ className, ...props }, ref) => {
+  const { dialogOverlay } = styles
+  return (
+    <RadixDialog.Overlay ref={ref} className={classNames(dialogOverlay, className)} {...props} />
+  )
+})
+Overlay.displayName = RadixDialog.Overlay.displayName
+
+/**
+ * The main content area of the dialog. Provides default styling, establishes the Portal, Overlay, and Close dialog components, and forwards an optional `ref`.
+ * @param {RadixDialog.DialogContentProps} props - Documentation: {@link https://www.radix-ui.com/primitives/docs/components/dialog#content}
+ */
+const Content = React.forwardRef<
+  React.ElementRef<typeof RadixDialog.Content>,
+  React.ComponentPropsWithoutRef<typeof RadixDialog.Content>
+>(({ className, children, ...props }, ref) => {
+  const { dialogContent, dialogClose } = styles
+  return (
+    <Portal>
+      <Overlay />
+      <RadixDialog.Content ref={ref} className={classNames(dialogContent, className)} {...props}>
+        {children}
+        <Close className={dialogClose}>
+          <FontAwesomeIcon icon={faWindowClose} size="lg" />
+          <span className="sr-only">Close</span>
+        </Close>
+      </RadixDialog.Content>
+    </Portal>
+  )
+})
+Content.displayName = RadixDialog.Content.displayName
+
+/**
+ * `div` container with default styling for the dialog's header content.
+ */
+const Header = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+  const { header } = styles
+  return <div className={classNames(header, className)} {...props} />
+}
+Header.displayName = "Dialog.Header"
+
+/**
+ * `div` container with default styling for the dialog's footer content.
+ */
+const Footer = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => {
+  const { footer } = styles
+  return <div className={classNames(footer, className)} {...props} />
+}
+Footer.displayName = "Dialog.Footer"
+
+/**
+ * The dialog's title text.
+ * Adds default styling and forwards an optional `ref`.
+ * Fits nicely into the `Dialog.Header` component.
+ * @param {RadixDialog.DialogTitleProps} props - Documentation: {@link https://www.radix-ui.com/primitives/docs/components/dialog#title}
+ */
+const Title = React.forwardRef<
+  React.ElementRef<typeof RadixDialog.Title>,
+  React.ComponentPropsWithoutRef<typeof RadixDialog.Title>
+>(({ className, ...props }, ref) => {
+  const { title } = styles
+  return <RadixDialog.Title ref={ref} className={classNames(title, className)} {...props} />
+})
+Title.displayName = RadixDialog.Title.displayName
+
+/**
+ * Descriptive text within the dialog.
+ * Adds default styling and forwards an optional `ref`.
+ * Fits nicely as a subheader in the `Dialog.Header` component.
+ * @param {RadixDialog.DialogDescriptionProps} props - Documentation: {@link https://www.radix-ui.com/primitives/docs/components/dialog#description}
+ */
+const Description = React.forwardRef<
+  React.ElementRef<typeof RadixDialog.Description>,
+  React.ComponentPropsWithoutRef<typeof RadixDialog.Description>
+>(({ className, ...props }, ref) => {
+  const { description } = styles
+  return (
+    <RadixDialog.Description ref={ref} className={classNames(description, className)} {...props} />
+  )
+})
+Description.displayName = RadixDialog.Description.displayName
+
+export { Root, Portal, Overlay, Close, Trigger, Content, Header, Footer, Title, Description }

--- a/frontend/shared-components/form/form.module.css
+++ b/frontend/shared-components/form/form.module.css
@@ -1,0 +1,17 @@
+.formItem {
+  margin-top: var(--size4);
+}
+
+.textDestructive {
+  color: var(--red);
+}
+
+.formDescription {
+  font-size: var(--size16);
+}
+
+.formMessage {
+  font-size: var(--size16);
+  font-weight: 500;
+  color: var(--red);
+}

--- a/frontend/shared-components/form/form.tsx
+++ b/frontend/shared-components/form/form.tsx
@@ -1,0 +1,216 @@
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import classNames from "classnames"
+import * as React from "react"
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  UseFormReturn,
+  useFormContext
+} from "react-hook-form"
+import useId from "../../helpers/hooks/useId"
+import { Label as FormLabel } from "../../shared-components"
+import styles from "./form.module.css"
+
+type FormProps<T extends FieldValues> = {
+  children: React.ReactNode
+  formMethods: UseFormReturn<T>
+} & React.FormHTMLAttributes<HTMLFormElement>
+
+/**
+ * Base component for creating forms.
+ * Wraps children elements with `FormProvider` from "react-hook-form" and a base `form` element.
+ * @param {React.ReactNode} children - any children components (form fields)
+ * @param {UseFormReturn<T>} formMethods - returned the `useForm()` hook from "react-hook-form"
+ * @param {React.FormHTMLAttributes<HTMLFormElement>} formProps - extends `HTMLFormElement` properties
+ */
+const Root = function <T extends FieldValues>({
+  children,
+  formMethods,
+  ...formProps
+}: FormProps<T>) {
+  return (
+    <FormProvider {...formMethods}>
+      <form {...formProps}>{children}</form>
+    </FormProvider>
+  )
+}
+Root.displayName = "Form"
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue)
+
+/**
+ * Defines a field within a `Form` component.
+ * Builds a controlled form field with `Controller` component from "react-hook-form".
+ * Provides field name to child components via context.
+ * @param {ControllerProps<TFieldValues, TName>} props - extends `Controller` props from "react-hook-form".  Documentation: {@link https://react-hook-form.com/docs/usecontroller/controller}
+ */
+const Field = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+Field.displayName = "FormField"
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue)
+
+/**
+ * Wrapper around form elements for accessibility purposes.
+ * Gives form elements an accessibility `id` via context.
+ * @param {React.HTMLAttributes<HTMLDivElement>} props - extends `HTMLDivElement` properties
+ */
+const Item = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    const { formItem } = styles
+    const id = useId()
+
+    return (
+      <FormItemContext.Provider value={{ id }}>
+        <div ref={ref} className={classNames(formItem, className)} {...props} />
+      </FormItemContext.Provider>
+    )
+  }
+)
+Item.displayName = "FormItem"
+
+/**
+ * Convenient hook used to get a form field's state with additional accessibility ID properties.
+ * @returns {object} field state with additional `id` properties for accessibility.
+ */
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <Form.Field>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState
+  }
+}
+
+/**
+ * Creates `<label>` element for the given form field.
+ * Adds default styling, and utilizes Radix UI for accessibility.
+ * @param {LabelPrimitive.LabelProps} props - extends Radix UI's `Label` element and `HTMLLabelElement` properties
+ */
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { textDestructive } = styles
+  const { error, formItemId } = useFormField()
+
+  return (
+    <FormLabel
+      ref={ref}
+      className={classNames(error && textDestructive, className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+})
+Label.displayName = "FormLabel"
+
+/**
+ * Directly wraps any form input component.
+ * Gives child component accessibility properties.
+ * @param {SlotProps & React.RefAttributes<HTMLElement>} props - extends `SlotProps` and `HTMLElement` properties
+ */
+const Control = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={!error ? `${formDescriptionId}` : `${formDescriptionId} ${formMessageId}`}
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+})
+Control.displayName = "FormControl"
+
+/**
+ * Helper component to give form field an optional `<p>` tag description.
+ * Connects it to form field for accessibility purposes.
+ * @param {HTMLParagraphElement} props - extends `HTMLParagraphElement` properties
+ */
+const Description = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescription } = styles
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={classNames(formDescription, className)}
+      {...props}
+    />
+  )
+})
+Description.displayName = "FormDescription"
+
+/**
+ * Responsible for showing error and related messages to the user.
+ * @param {HTMLParagraphElement} props - extends `HTMLParagraphElement` properties
+ */
+const Message = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, children, ...props }, ref) => {
+    const { formMessage } = styles
+    const { error, formMessageId } = useFormField()
+    const body = error ? String(error?.message) : children
+
+    if (!body) {
+      return null
+    }
+
+    return (
+      <p ref={ref} id={formMessageId} className={classNames(formMessage, className)} {...props}>
+        {body}
+      </p>
+    )
+  }
+)
+Message.displayName = "FormMessage"
+
+export { Control, Description, Field, Item, Label, Message, Root, useFormField }

--- a/frontend/shared-components/index.tsx
+++ b/frontend/shared-components/index.tsx
@@ -1,31 +1,45 @@
-import ExternalLink from "./external-link/external-link"
+import CreateOrganizationBtn from "./create-organization-btn/create-organization-btn"
+import { DataTable } from "./data-table/data-table"
+import * as Dialog from "./dialog/dialog"
 import FormLevelError from "./error-form-level/error-form-level"
+import ExternalLink from "./external-link/external-link"
+import * as Form from "./form/form"
 import InfoTooltip from "./info-tooltip/info-tooltip"
+import Input from "./input/input"
+import Label from "./label/label"
 import Layout from "./layout/layout"
-import Logo from "./logo/logo"
-import PrimaryInput from "./primary-input/primary-input"
-import SecondaryInput from "./secondary-input/secondary-input"
-import ResponseTextArea from "./response-textarea/response-textarea"
-import USAStateInput from "./state-input/state-input"
-import PrimaryButton from "./primary-button/primary-button"
 import LinkButton from "./link-button/link-button"
+import Logo from "./logo/logo"
+import PrimaryButton from "./primary-button/primary-button"
+import PrimaryInput from "./primary-input/primary-input"
+import ResponseTextArea from "./response-textarea/response-textarea"
 import ResultsAlert from "./results-alert/results-alert"
+import SecondaryInput from "./secondary-input/secondary-input"
+import * as Select from "./select/select"
+import USAStateInput from "./state-input/state-input"
 import SuccessMessage from "./success-message/success-message"
 import { ToggleBox } from "./toggle-box/toggle-box"
 
 export {
+  CreateOrganizationBtn,
+  DataTable,
+  Dialog,
   ExternalLink,
+  Form,
   FormLevelError,
   InfoTooltip,
+  Input,
+  Label,
   Layout,
+  LinkButton,
   Logo,
   PrimaryButton,
-  LinkButton,
   PrimaryInput,
-  SecondaryInput,
   ResponseTextArea,
-  USAStateInput,
   ResultsAlert,
+  SecondaryInput,
+  Select,
   SuccessMessage,
-  ToggleBox
+  ToggleBox,
+  USAStateInput
 }

--- a/frontend/shared-components/input/input.module.css
+++ b/frontend/shared-components/input/input.module.css
@@ -1,0 +1,29 @@
+.input {
+  display: flex;
+  height: var(--size40);
+  width: 100%;
+  border: 1px solid #000;
+  border-radius: var(--size4);
+  background-color: var(--white);
+  padding: var(--size4) var(--size8);
+  font-size: var(--size16);
+}
+
+.input[type="file"] {
+  border: none;
+  background-color: transparent;
+}
+
+.input::placeholder {
+  color: var(--grey);
+}
+
+.input:focus-visible {
+  outline: none;
+  box-shadow: var(--size-4) 0 0 0 calc(2px + var(--size-4)) #000;
+}
+
+.input:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}

--- a/frontend/shared-components/input/input.tsx
+++ b/frontend/shared-components/input/input.tsx
@@ -1,0 +1,17 @@
+import * as React from "react"
+import classNames from "classnames"
+import styles from "./input.module.css"
+
+/**
+ * `<input>` tag with default stylings.
+ * @param {React.InputHTMLAttributes<HTMLInputElement>} props - extends `HTMLInputElement` properties
+ */
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type, ...props }, ref) => {
+    const { input } = styles
+    return <input type={type} className={classNames(input, className)} ref={ref} {...props} />
+  }
+)
+Input.displayName = "Input"
+
+export default Input

--- a/frontend/shared-components/label/label.module.css
+++ b/frontend/shared-components/label/label.module.css
@@ -1,0 +1,10 @@
+.labelStyles {
+  font-size: var(--size16);
+  font-weight: 500;
+  line-height: 1;
+}
+
+input:disabled ~ .labelStyles {
+  cursor: not-allowed;
+  opacity: 0.7;
+}

--- a/frontend/shared-components/label/label.tsx
+++ b/frontend/shared-components/label/label.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import classNames from "classnames"
+import styles from "./label.module.css"
+
+/**
+ * Base `<label>` component that adds default stylings and accessibility features.
+ * Extends Radix UI's `Label` component.
+ * @param {LabelPrimitive.LabelProps} props - extends Radix UI's `Label` component
+ * @see Documentation: {@link https://www.radix-ui.com/primitives/docs/components/label#root}
+ */
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(function LabelComponent({ className, ...props }, ref) {
+  const { labelStyles } = styles
+  return <LabelPrimitive.Root ref={ref} className={classNames(labelStyles, className)} {...props} />
+})
+Label.displayName = LabelPrimitive.Root.displayName
+
+export default Label

--- a/frontend/shared-components/primary-button/primary-button.tsx
+++ b/frontend/shared-components/primary-button/primary-button.tsx
@@ -4,17 +4,28 @@ import classnames from "classnames"
 
 export interface Props extends React.HTMLProps<HTMLButtonElement> {
   loading?: boolean
+  type?: "button" | "submit" | "reset"
 }
-export default function PrimaryButton({ className, loading, children, ...rest }: Props) {
+
+const Button = React.forwardRef<HTMLButtonElement, Props>(function PrimaryButton(
+  { className, loading, type, children, ...rest }: Props,
+  ref
+) {
   return (
-    <button {...rest} className={classnames(styles.primaryButton, className)} type="submit">
+    <button
+      ref={ref}
+      type={type || "submit"}
+      className={classnames(styles.primaryButton, className)}
+      {...rest}>
       {loading ? <Spinner /> : children}
     </button>
   )
-}
+})
 
 const Spinner = () => (
   <svg className={styles.spinner} viewBox="0 0 50 50">
     <circle className={styles.path} cx="25" cy="25" r="20" fill="none" strokeWidth="5"></circle>
   </svg>
 )
+
+export default Button

--- a/frontend/shared-components/select/select.module.css
+++ b/frontend/shared-components/select/select.module.css
@@ -1,0 +1,130 @@
+.trigger {
+  display: flex;
+  height: var(--size40);
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid #000;
+  border-radius: var(--size4);
+  padding: var(--size4) var(--size8);
+  font-size: var(--size16);
+}
+
+.trigger:focus-visible {
+  outline: none;
+  box-shadow: var(--size-4) 0 0 0 calc(2px + var(--size-4)) #000;
+}
+
+.trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.trigger > span {
+  line-clamp: 1;
+}
+
+.scrollBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0;
+  cursor: default;
+}
+
+.content {
+  position: relative;
+  z-index: 50;
+  max-height: var(--size200);
+  min-width: 8rem;
+  overflow: hidden;
+  border-radius: 0.375rem;
+  border: 1px solid var(--white);
+  background-color: #fff;
+  box-shadow: 0 0 0 1px var(--lightBlue);
+}
+
+.content[data-state="open"] {
+  animation: fadeIn 100ms ease-in-out forwards;
+}
+
+.content[data-state="closed"] {
+  animation: fadeOut 100ms ease-in-out forwards;
+}
+
+.content.popper {
+  box-shadow: 0 0 0 1px var(--lightBlue);
+}
+
+.contentViewport {
+  padding: 0.25rem;
+}
+
+.contentViewport.popper {
+  /* variables exposed by Radix UI: https://www.radix-ui.com/primitives/docs/components/select#content */
+  height: var(--radix-select-trigger-height);
+  width: 100%;
+  min-width: var(--radix-select-trigger-width);
+}
+
+.label {
+  padding: 0.375rem 2rem 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.item {
+  position: relative;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  padding: 0.375rem 0.5rem 0.375rem 2rem;
+  border-radius: 0.125rem;
+  font-size: 0.875rem;
+  outline: none;
+  cursor: default;
+}
+
+.item:focus {
+  background-color: var(--lightBlue);
+  color: #fff;
+}
+
+.item:disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.itemIndicator {
+  position: absolute;
+  left: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--size16);
+  width: var(--size16);
+}
+
+.separator {
+  height: 1px;
+  margin: 0.25rem -0.25rem;
+  background-color: #ccc;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}

--- a/frontend/shared-components/select/select.tsx
+++ b/frontend/shared-components/select/select.tsx
@@ -1,0 +1,147 @@
+import { faArrowDown, faArrowUp, faCheck } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import * as RadixSelect from "@radix-ui/react-select"
+import classNames from "classnames"
+import * as React from "react"
+import styles from "./select.module.css"
+
+/**
+ * @see Documentation: {@link https://www.radix-ui.com/primitives/docs/components/select#root}
+ */
+const Root = RadixSelect.Root
+
+/**
+ * @see Documentation: {@link https://www.radix-ui.com/primitives/docs/components/select#group}
+ */
+const Group = RadixSelect.Group
+
+/**
+ * @see Documentation: {@link https://www.radix-ui.com/primitives/docs/components/select#value}
+ */
+const Value = RadixSelect.Value
+
+/**
+ * @see Documentation: {@link https://www.radix-ui.com/primitives/docs/components/select#trigger}
+ */
+const Trigger = React.forwardRef<
+  React.ElementRef<typeof RadixSelect.Trigger>,
+  React.ComponentPropsWithoutRef<typeof RadixSelect.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <RadixSelect.Trigger ref={ref} className={classNames(styles.trigger, className)} {...props}>
+    {children}
+    <RadixSelect.Icon asChild>
+      <FontAwesomeIcon icon={faArrowDown} />
+    </RadixSelect.Icon>
+  </RadixSelect.Trigger>
+))
+Trigger.displayName = RadixSelect.Trigger.displayName
+
+/**
+ * @see Documentation: {@link https://www.radix-ui.com/primitives/docs/components/select#scrollupbutton}
+ */
+const ScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof RadixSelect.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof RadixSelect.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <RadixSelect.ScrollUpButton
+    ref={ref}
+    className={classNames(styles.scrollBtn, className)}
+    {...props}>
+    <FontAwesomeIcon icon={faArrowUp} />
+  </RadixSelect.ScrollUpButton>
+))
+ScrollUpButton.displayName = RadixSelect.ScrollUpButton.displayName
+
+/**
+ * @see Documentation: {@link https://www.radix-ui.com/primitives/docs/components/select#scrolldownbutton}
+ */
+const ScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof RadixSelect.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof RadixSelect.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <RadixSelect.ScrollDownButton
+    ref={ref}
+    className={classNames(styles.scrollBtn, className)}
+    {...props}>
+    <FontAwesomeIcon icon={faArrowDown} />
+  </RadixSelect.ScrollDownButton>
+))
+ScrollDownButton.displayName = RadixSelect.ScrollDownButton.displayName
+
+/**
+ * @see Documentation: {@link https://www.radix-ui.com/primitives/docs/components/select#content}
+ */
+const Content = React.forwardRef<
+  React.ElementRef<typeof RadixSelect.Content>,
+  React.ComponentPropsWithoutRef<typeof RadixSelect.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <RadixSelect.Portal>
+    <RadixSelect.Content
+      ref={ref}
+      className={classNames(styles.content, position === "popper" && styles.popper, className)}
+      position={position}
+      {...props}>
+      <ScrollUpButton />
+      <RadixSelect.Viewport
+        className={classNames(styles.contentViewport, position === "popper" && styles.popper)}>
+        {children}
+      </RadixSelect.Viewport>
+      <ScrollDownButton />
+    </RadixSelect.Content>
+  </RadixSelect.Portal>
+))
+Content.displayName = RadixSelect.Content.displayName
+
+/**
+ * @see Documentation: {@link https://www.radix-ui.com/primitives/docs/components/select#label}
+ */
+const Label = React.forwardRef<
+  React.ElementRef<typeof RadixSelect.Label>,
+  React.ComponentPropsWithoutRef<typeof RadixSelect.Label>
+>(({ className, ...props }, ref) => (
+  <RadixSelect.Label ref={ref} className={classNames(styles.label, className)} {...props} />
+))
+Label.displayName = RadixSelect.Label.displayName
+
+/**
+ * @see Documentation: {@link https://www.radix-ui.com/primitives/docs/components/select#item}
+ */
+const Item = React.forwardRef<
+  React.ElementRef<typeof RadixSelect.Item>,
+  React.ComponentPropsWithoutRef<typeof RadixSelect.Item>
+>(({ className, children, ...props }, ref) => (
+  <RadixSelect.Item ref={ref} className={classNames(styles.item, className)} {...props}>
+    <span className={styles.itemIndicator}>
+      <RadixSelect.ItemIndicator>
+        <FontAwesomeIcon icon={faCheck} />
+      </RadixSelect.ItemIndicator>
+    </span>
+
+    <RadixSelect.ItemText>{children}</RadixSelect.ItemText>
+  </RadixSelect.Item>
+))
+Item.displayName = RadixSelect.Item.displayName
+
+/**
+ * @see Documentation: {@link https://www.radix-ui.com/primitives/docs/components/select#separator}
+ */
+const Separator = React.forwardRef<
+  React.ElementRef<typeof RadixSelect.Separator>,
+  React.ComponentPropsWithoutRef<typeof RadixSelect.Separator>
+>(({ className, ...props }, ref) => (
+  <RadixSelect.Separator ref={ref} className={classNames(styles.separator, className)} {...props} />
+))
+Separator.displayName = RadixSelect.Separator.displayName
+
+export {
+  Content,
+  Group,
+  Item,
+  Label,
+  Root,
+  ScrollDownButton,
+  ScrollUpButton,
+  Separator,
+  Trigger,
+  Value
+}

--- a/frontend/tests/snapshots/__snapshots__/profile.test.tsx.snap
+++ b/frontend/tests/snapshots/__snapshots__/profile.test.tsx.snap
@@ -30,6 +30,16 @@ exports[`renders Profile Page correctly 1`] = `
           >
             Saved Searches
           </li>
+          <li
+            class="menuItem"
+          >
+            Notifications
+          </li>
+          <li
+            class="menuItem"
+          >
+            My Organizations
+          </li>
         </ul>
       </nav>
       <div

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11906,10 +11906,10 @@
     "react-fast-compare" "^3.2.0"
     "shallowequal" "^1.1.0"
 
-"react-hook-form@^7.0.0", "react-hook-form@^7.50.1":
-  "integrity" "sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ=="
-  "resolved" "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.1.tgz"
-  "version" "7.50.1"
+"react-hook-form@^7.0.0", "react-hook-form@^7.25.0":
+  "integrity" "sha512-MyF4YXegIT/vfyZloTm98mpJwLUPfULdX37yPzXeijT1hePCkV8DN1IAnEufxgtqCpc7aFGRinegQwisUGZCnA=="
+  "resolved" "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.25.0.tgz"
+  "version" "7.25.0"
 
 "react-inspector@^5.1.0":
   "integrity" "sha512-GURDaYzoLbW8pMGXwYPDBIv6nqei4kK7LPRZ9q9HCZF54wqXz/dnylBp/kfE9XmekBhHvLDdcYeyIwSrvtOiWg=="
@@ -12061,7 +12061,7 @@
     "@floating-ui/dom" "^1.0.0"
     "classnames" "^2.3.0"
 
-"react@*", "react@^0.14.0 || ^15.0.0 || ^16.0.0", "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1", "react@^16.0.0 || ^17.0.0", "react@^16.13.1 || ^17.0.0", "react@^16.6.0 || ^17.0.0", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8.0 || ^17", "react@^16.8.0 || ^17 || ^18", "react@^16.8.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.3 || ^17.0.0-0", "react@^16.8.4 || ^17.0.0", "react@^17.0.2", "react@>= 0.14.0", "react@>= 16.3.0", "react@>= 16.8.0 || 17.x.x || 18.x.x", "react@>=16.12.0", "react@>=16.13.1", "react@>=16.14.0", "react@>=16.3.0", "react@>=16.8.0", "react@>=16.9.0", "react@>=16.x", "react@>=17.0.0", "react@15.x || 16.x || 16.4.0-alpha.0911da3", "react@17.0.2":
+"react@*", "react@^0.14.0 || ^15.0.0 || ^16.0.0", "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1", "react@^16.0.0 || ^17.0.0", "react@^16.13.1 || ^17.0.0", "react@^16.6.0 || ^17.0.0", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8.0 || ^17", "react@^16.8.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.3 || ^17.0.0-0", "react@^16.8.4 || ^17.0.0", "react@^17.0.2", "react@>= 0.14.0", "react@>= 16.3.0", "react@>= 16.8.0 || 17.x.x || 18.x.x", "react@>=16.12.0", "react@>=16.13.1", "react@>=16.14.0", "react@>=16.3.0", "react@>=16.8.0", "react@>=16.9.0", "react@>=16.x", "react@>=17.0.0", "react@15.x || 16.x || 16.4.0-alpha.0911da3", "react@17.0.2":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   "version" "17.0.2"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1078,7 +1078,7 @@
     "core-js-pure" "^3.16.0"
     "regenerator-runtime" "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2", "@babel/runtime@7.15.3":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2", "@babel/runtime@7.15.3":
   "integrity" "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA=="
   "resolved" "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz"
   "version" "7.15.3"
@@ -1290,22 +1290,29 @@
     "minimatch" "^3.0.4"
     "strip-json-comments" "^3.1.1"
 
-"@floating-ui/core@^1.5.3":
-  "integrity" "sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q=="
-  "resolved" "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.3.tgz"
-  "version" "1.5.3"
+"@floating-ui/core@^1.6.0":
+  "integrity" "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g=="
+  "resolved" "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz"
+  "version" "1.6.0"
   dependencies:
-    "@floating-ui/utils" "^0.2.0"
+    "@floating-ui/utils" "^0.2.1"
 
-"@floating-ui/dom@^1.0.0":
-  "integrity" "sha512-jByEsHIY+eEdCjnTVu+E3ephzTOzkQ8hgUfGwos+bg7NlH33Zc5uO+QHz1mrQUOgIKKDD1RtS201P9NvAfq3XQ=="
-  "resolved" "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.4.tgz"
-  "version" "1.5.4"
+"@floating-ui/dom@^1.0.0", "@floating-ui/dom@^1.6.1":
+  "integrity" "sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ=="
+  "resolved" "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.1.tgz"
+  "version" "1.6.1"
   dependencies:
-    "@floating-ui/core" "^1.5.3"
-    "@floating-ui/utils" "^0.2.0"
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.1"
 
-"@floating-ui/utils@^0.2.0":
+"@floating-ui/react-dom@^2.0.0":
+  "integrity" "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw=="
+  "resolved" "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz"
+  "version" "2.0.8"
+  dependencies:
+    "@floating-ui/dom" "^1.6.1"
+
+"@floating-ui/utils@^0.2.1":
   "integrity" "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
   "resolved" "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz"
   "version" "0.2.1"
@@ -1381,6 +1388,11 @@
   "integrity" "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
   "resolved" "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz"
   "version" "9.2.1"
+
+"@hookform/resolvers@^3.3.4":
+  "integrity" "sha512-o5cgpGOuJYrd+iMKvkttOclgwRW86EsWJZZRC23prf0uU2i48Htq4PuT73AVb9ionFyZrwYEITuOFGF+BydEtQ=="
+  "resolved" "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.4.tgz"
+  "version" "3.3.4"
 
 "@humanwhocodes/config-array@^0.5.0":
   "integrity" "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg=="
@@ -1839,6 +1851,312 @@
   "integrity" "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
   "resolved" "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz"
   "version" "2.10.2"
+
+"@radix-ui/number@1.0.1":
+  "integrity" "sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/primitive@1.0.1":
+  "integrity" "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-arrow@1.0.3":
+  "integrity" "sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz"
+  "version" "1.0.3"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-collection@1.0.3":
+  "integrity" "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz"
+  "version" "1.0.3"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+
+"@radix-ui/react-compose-refs@1.0.1":
+  "integrity" "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@1.0.1":
+  "integrity" "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dialog@^1.0.5":
+  "integrity" "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz"
+  "version" "1.0.5"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "aria-hidden" "^1.1.1"
+    "react-remove-scroll" "2.5.5"
+
+"@radix-ui/react-direction@1.0.1":
+  "integrity" "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dismissable-layer@1.0.5":
+  "integrity" "sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz"
+  "version" "1.0.5"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-escape-keydown" "1.0.3"
+
+"@radix-ui/react-focus-guards@1.0.1":
+  "integrity" "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-focus-scope@1.0.4":
+  "integrity" "sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz"
+  "version" "1.0.4"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-id@1.0.1":
+  "integrity" "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-label@^2.0.2":
+  "integrity" "sha512-N5ehvlM7qoTLx7nWPodsPYPgMzA5WM8zZChQg8nyFJKnDO5WHdba1vv5/H6IO5LtJMfD2Q3wh1qHFGNtK0w3bQ=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.0.2.tgz"
+  "version" "2.0.2"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-popper@1.1.3":
+  "integrity" "sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.1.3.tgz"
+  "version" "1.1.3"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-rect" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+    "@radix-ui/rect" "1.0.1"
+
+"@radix-ui/react-portal@1.0.4":
+  "integrity" "sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.4.tgz"
+  "version" "1.0.4"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-presence@1.0.1":
+  "integrity" "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-primitive@1.0.3":
+  "integrity" "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz"
+  "version" "1.0.3"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.2"
+
+"@radix-ui/react-roving-focus@1.0.4":
+  "integrity" "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz"
+  "version" "1.0.4"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-select@^2.0.0":
+  "integrity" "sha512-RH5b7af4oHtkcHS7pG6Sgv5rk5Wxa7XI8W5gvB1N/yiuDGZxko1ynvOiVhFM7Cis2A8zxF9bTOUVbRDzPepe6w=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.0.0.tgz"
+  "version" "2.0.0"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/number" "1.0.1"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-previous" "1.0.1"
+    "@radix-ui/react-visually-hidden" "1.0.3"
+    "aria-hidden" "^1.1.1"
+    "react-remove-scroll" "2.5.5"
+
+"@radix-ui/react-slot@^1.0.2", "@radix-ui/react-slot@1.0.2":
+  "integrity" "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz"
+  "version" "1.0.2"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+
+"@radix-ui/react-toggle-group@^1.0.4":
+  "integrity" "sha512-Uaj/M/cMyiyT9Bx6fOZO0SAG4Cls0GptBWiBmBxofmDbNVnYYoyRWj/2M/6VCi/7qcXFWnHhRUfdfZFvvkuu8A=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.0.4.tgz"
+  "version" "1.0.4"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-toggle" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-toggle@1.0.3":
+  "integrity" "sha512-Pkqg3+Bc98ftZGsl60CLANXQBBQ4W3mTFS9EJvNxKMZ7magklKV69/id1mlAlOFDDfHvlCms0fx8fA4CMKDJHg=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.0.3.tgz"
+  "version" "1.0.3"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
+"@radix-ui/react-use-callback-ref@1.0.1":
+  "integrity" "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-controllable-state@1.0.1":
+  "integrity" "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-use-escape-keydown@1.0.3":
+  "integrity" "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz"
+  "version" "1.0.3"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-use-layout-effect@1.0.1":
+  "integrity" "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-previous@1.0.1":
+  "integrity" "sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-rect@1.0.1":
+  "integrity" "sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/rect" "1.0.1"
+
+"@radix-ui/react-use-size@1.0.1":
+  "integrity" "sha512-ibay+VqrgcaI6veAojjofPATwledXiSmX+C0KrBk/xgpX9rBzPV3OsfwlhQdUOFbh+LKQorLYT+xTXW9V8yd0g=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-visually-hidden@1.0.3":
+  "integrity" "sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz"
+  "version" "1.0.3"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/rect@1.0.1":
+  "integrity" "sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ=="
+  "resolved" "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.0.1.tgz"
+  "version" "1.0.1"
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@reach/router@^1.3.4":
   "integrity" "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA=="
@@ -3186,7 +3504,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@>=16.9.0":
+"@types/react-dom@*", "@types/react-dom@>=16.9.0":
   "integrity" "sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg=="
   "resolved" "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz"
   "version" "17.0.9"
@@ -3214,7 +3532,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.5", "@types/react@>=16.9.0":
+"@types/react@*", "@types/react@^16.8.0 || ^17.0.0 || ^18.0.0", "@types/react@^16.9.0 || ^17.0.0 || ^18.0.0", "@types/react@^17.0.5", "@types/react@>=16.9.0":
   "integrity" "sha512-zgiJwtsggVGtr53MndV7jfiUESTqrbxOcBvwfe6KS/9bzaVPCTDieTWnFNecVNx6EAaapg5xsLLWFfHHR437AA=="
   "resolved" "https://registry.npmjs.org/@types/react/-/react-17.0.27.tgz"
   "version" "17.0.27"
@@ -3944,6 +4262,13 @@
   "version" "1.0.10"
   dependencies:
     "sprintf-js" "~1.0.2"
+
+"aria-hidden@^1.1.1":
+  "integrity" "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ=="
+  "resolved" "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz"
+  "version" "1.2.3"
+  dependencies:
+    "tslib" "^2.0.0"
 
 "aria-query@^4.2.2":
   "integrity" "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA=="
@@ -6055,6 +6380,11 @@
   "resolved" "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz"
   "version" "3.1.0"
 
+"detect-node-es@^1.1.0":
+  "integrity" "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+  "resolved" "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz"
+  "version" "1.1.0"
+
 "detect-port-alt@1.1.6":
   "integrity" "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q=="
   "resolved" "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz"
@@ -7376,6 +7706,11 @@
     "function-bind" "^1.1.1"
     "has" "^1.0.3"
     "has-symbols" "^1.0.1"
+
+"get-nonce@^1.0.0":
+  "integrity" "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
+  "resolved" "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz"
+  "version" "1.0.1"
 
 "get-orientation@1.1.2":
   "integrity" "sha512-/pViTfifW+gBbh/RnlFYHINvELT9Znt+SYyDKAUL6uV6By019AK/s+i9XP4jSwq7lwP38Fd8HVeTxym3+hkwmQ=="
@@ -11518,7 +11853,7 @@
     "node-dir" "^0.1.10"
     "strip-indent" "^3.0.0"
 
-"react-dom@*", "react-dom@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1", "react-dom@^16.6.0 || ^17.0.0", "react-dom@^16.8.0 || ^17.0.0", "react-dom@^17.0.2", "react-dom@>= 16.3.0", "react-dom@>=16.14.0", "react-dom@>=16.8.0", "react-dom@>=16.9.0", "react-dom@15.x || 16.x || 16.4.0-alpha.0911da3":
+"react-dom@*", "react-dom@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1", "react-dom@^16.6.0 || ^17.0.0", "react-dom@^16.8 || ^17.0 || ^18.0", "react-dom@^16.8.0 || ^17.0.0", "react-dom@^17.0.2", "react-dom@>= 16.3.0", "react-dom@>=16.14.0", "react-dom@>=16.8.0", "react-dom@>=16.9.0", "react-dom@15.x || 16.x || 16.4.0-alpha.0911da3":
   "integrity" "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA=="
   "resolved" "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz"
   "version" "17.0.2"
@@ -11571,10 +11906,10 @@
     "react-fast-compare" "^3.2.0"
     "shallowequal" "^1.1.0"
 
-"react-hook-form@^7.15.0":
-  "integrity" "sha512-9nQ+qKFHFpnWzQHdDh6F4Egxa8iJkue1KU921F8qqeyUVbPPjgQZDXaQyNHABEYjRh0ndjTI24GDA+lwm2lQdg=="
-  "resolved" "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.17.1.tgz"
-  "version" "7.17.1"
+"react-hook-form@^7.0.0", "react-hook-form@^7.50.1":
+  "integrity" "sha512-3PCY82oE0WgeOgUtIr3nYNNtNvqtJ7BZjsbxh6TnYNbXButaD5WpjOmTjdxZfheuHKR68qfeFnEDVYoSSFPMTQ=="
+  "resolved" "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.50.1.tgz"
+  "version" "7.50.1"
 
 "react-inspector@^5.1.0":
   "integrity" "sha512-GURDaYzoLbW8pMGXwYPDBIv6nqei4kK7LPRZ9q9HCZF54wqXz/dnylBp/kfE9XmekBhHvLDdcYeyIwSrvtOiWg=="
@@ -11627,6 +11962,25 @@
   "resolved" "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz"
   "version" "0.8.3"
 
+"react-remove-scroll-bar@^2.3.3":
+  "integrity" "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A=="
+  "resolved" "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz"
+  "version" "2.3.4"
+  dependencies:
+    "react-style-singleton" "^2.2.1"
+    "tslib" "^2.0.0"
+
+"react-remove-scroll@2.5.5":
+  "integrity" "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw=="
+  "resolved" "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz"
+  "version" "2.5.5"
+  dependencies:
+    "react-remove-scroll-bar" "^2.3.3"
+    "react-style-singleton" "^2.2.1"
+    "tslib" "^2.1.0"
+    "use-callback-ref" "^1.3.0"
+    "use-sidecar" "^1.1.2"
+
 "react-responsive@^9.0.0-beta.4":
   "integrity" "sha512-jQSs5kIi38T39Ku98r8s75jM6JAaNEeVrHPHTrL2EYWuv8nusV3KRQcZZ4VlfwndIRedxmpb4T8FXA9ltlCFiw=="
   "resolved" "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.0-beta.4.tgz"
@@ -11654,6 +12008,15 @@
     "invariant" "^2.2.4"
     "shallowequal" "^1.1.0"
     "throttle-debounce" "^3.0.1"
+
+"react-style-singleton@^2.2.1":
+  "integrity" "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g=="
+  "resolved" "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz"
+  "version" "2.2.1"
+  dependencies:
+    "get-nonce" "^1.0.0"
+    "invariant" "^2.2.4"
+    "tslib" "^2.0.0"
 
 "react-syntax-highlighter@^13.5.3":
   "integrity" "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg=="
@@ -11698,7 +12061,7 @@
     "@floating-ui/dom" "^1.0.0"
     "classnames" "^2.3.0"
 
-"react@*", "react@^0.14.0 || ^15.0.0 || ^16.0.0", "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1", "react@^16.0.0 || ^17.0.0", "react@^16.13.1 || ^17.0.0", "react@^16.6.0 || ^17.0.0", "react@^16.8.0 || ^17", "react@^16.8.0 || ^17.0.0", "react@^16.8.3 || ^17.0.0-0", "react@^16.8.4 || ^17.0.0", "react@^17.0.2", "react@>= 0.14.0", "react@>= 16.3.0", "react@>= 16.8.0 || 17.x.x || 18.x.x", "react@>=16.12.0", "react@>=16.13.1", "react@>=16.14.0", "react@>=16.3.0", "react@>=16.8.0", "react@>=16.9.0", "react@>=16.x", "react@>=17.0.0", "react@15.x || 16.x || 16.4.0-alpha.0911da3", "react@17.0.2":
+"react@*", "react@^0.14.0 || ^15.0.0 || ^16.0.0", "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1", "react@^16.0.0 || ^17.0.0", "react@^16.13.1 || ^17.0.0", "react@^16.6.0 || ^17.0.0", "react@^16.8 || ^17.0 || ^18.0", "react@^16.8.0 || ^17", "react@^16.8.0 || ^17 || ^18", "react@^16.8.0 || ^17.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.3 || ^17.0.0-0", "react@^16.8.4 || ^17.0.0", "react@^17.0.2", "react@>= 0.14.0", "react@>= 16.3.0", "react@>= 16.8.0 || 17.x.x || 18.x.x", "react@>=16.12.0", "react@>=16.13.1", "react@>=16.14.0", "react@>=16.3.0", "react@>=16.8.0", "react@>=16.9.0", "react@>=16.x", "react@>=17.0.0", "react@15.x || 16.x || 16.4.0-alpha.0911da3", "react@17.0.2":
   "integrity" "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA=="
   "resolved" "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
   "version" "17.0.2"
@@ -13553,7 +13916,7 @@
   "resolved" "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   "version" "1.14.1"
 
-"tslib@^2.0.0", "tslib@^2.0.1", "tslib@^2.0.3", "tslib@^2.3.0":
+"tslib@^2.0.0", "tslib@^2.0.1", "tslib@^2.0.3", "tslib@^2.1.0", "tslib@^2.3.0":
   "integrity" "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
   "resolved" "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
   "version" "2.3.1"
@@ -13861,6 +14224,13 @@
     "punycode" "1.3.2"
     "querystring" "0.2.0"
 
+"use-callback-ref@^1.3.0":
+  "integrity" "sha512-Lg4Vx1XZQauB42Hw3kK7JM6yjVjgFmFC5/Ab797s79aARomD2nEErc4mCgM8EZrARLmmbWpi5DGCadmK50DcAQ=="
+  "resolved" "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.1.tgz"
+  "version" "1.3.1"
+  dependencies:
+    "tslib" "^2.0.0"
+
 "use-composed-ref@^1.0.0":
   "integrity" "sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg=="
   "resolved" "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz"
@@ -13886,6 +14256,14 @@
   "version" "7.0.1"
   dependencies:
     "resize-observer-polyfill" "^1.5.1"
+
+"use-sidecar@^1.1.2":
+  "integrity" "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw=="
+  "resolved" "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz"
+  "version" "1.1.2"
+  dependencies:
+    "detect-node-es" "^1.1.0"
+    "tslib" "^2.0.0"
 
 "use-subscription@1.5.1":
   "integrity" "sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA=="
@@ -14460,6 +14838,11 @@
   "integrity" "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
   "resolved" "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   "version" "0.1.0"
+
+"zod@^3.22.4":
+  "integrity" "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
+  "resolved" "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz"
+  "version" "3.22.4"
 
 "zwitch@^1.0.0":
   "integrity" "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="


### PR DESCRIPTION
Sorry for the code bomb!  This PR contains foundational UI components for building out Epic 2's UI, as well as the UI for the Profile page's "Notifications" view and "My Organizations" view when the user has no organizations.

# Changes
## Foundational UI components added:
 - Dialog (modals)
 - Form
 - Label
 - Input
 - Select
 - `CreateOrganizationBtn`: button component that activates a modal dialog containing the form for creating organizations.
## Layout UI components added:
 - `ProfileNotifications` view for user's invitations to organizations
 - `ProfileOrganizations` view for viewing user's organizations.
 - Updated `profile` page base component to incorporate two new views.
## Libraries Introduced
 - **Radix UI** -- open-source component library with unstyled components focused on ease of use and accessibility.  More here: [https://www.radix-ui.com/primitives](https://www.radix-ui.com/primitives)
 - **Shadcn/ui** -- based foundational UI components off this copy/paste library (**no dependency needed**).  Contains default styles that look amazing, and the library is based off Radix UI.  I converted the Tailwind classes the library provides to CSS modules that fit with NPDC.  More here: [https://ui.shadcn.com/](https://ui.shadcn.com/)
 - **Zod** -- a library for TypeScript-first schema validations, used primarily for easy and effective form validation.  More here: [https://zod.dev/?id=introduction](https://zod.dev/?id=introduction)
 - **@hookform/resolvers** -- an easy to use package that connects Zod schemas to React Hook Form for easy and effective form validation.  More here: [https://www.npmjs.com/package/@hookform/resolvers](https://www.npmjs.com/package/@hookform/resolvers)

# Screenshots
<img width="1345" alt="Screenshot 2024-02-11 at 5 33 06 PM" src="https://github.com/codeforboston/police-data-trust/assets/97762447/ea9721a9-34b2-4b08-80ef-3a63d919fd34">
<img width="1342" alt="Screenshot 2024-02-11 at 5 35 19 PM" src="https://github.com/codeforboston/police-data-trust/assets/97762447/f4feb22f-cbe7-4a2d-9168-2d643aef57b5">
<img width="1341" alt="Screenshot 2024-02-11 at 5 33 29 PM" src="https://github.com/codeforboston/police-data-trust/assets/97762447/6a4bbdf2-9ddd-42d7-836b-6e99d99658a6">
<img width="1342" alt="Screenshot 2024-02-11 at 5 33 55 PM" src="https://github.com/codeforboston/police-data-trust/assets/97762447/a989086f-7d50-4452-967b-f0b408ae3be4">
<img width="1337" alt="Screenshot 2024-02-11 at 5 34 21 PM" src="https://github.com/codeforboston/police-data-trust/assets/97762447/955a99fb-2210-4a4c-8e8b-4d7d5dd56870">
<img width="1341" alt="Screenshot 2024-02-11 at 5 34 43 PM" src="https://github.com/codeforboston/police-data-trust/assets/97762447/70144426-56b7-4952-bfa0-aa9ba7e7c012">
<img width="1344" alt="Screenshot 2024-02-11 at 5 35 03 PM" src="https://github.com/codeforboston/police-data-trust/assets/97762447/1c5c3923-43f0-499f-878a-29857381bb78">

