### PR TITLE
WIP: update node to fix firebase gh action

### DIFF
--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: "Version used by actions/setup-node"
     required: true
-    default: "16"
+    default: "20"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
- firebase publish failing because it expects node 18 or 20, but is set to version 16.