### PR TITLE
 [FEAT] Convert the Unit property into a db Unit model

### DIFF
--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -11,6 +11,7 @@ from backend.database.core import execute_query
 #  Alembic only does a couple models, not all of them.
 
 from .models.agency import *
+from .models.unit import *
 from .models.attorney import *
 from .models.case_document import *
 from .models.incident import *

--- a/backend/database/models/agency.py
+++ b/backend/database/models/agency.py
@@ -20,6 +20,7 @@ class Agency(db.Model, CrudMixin):
     hq_city = db.Column(db.Text)
     hq_zip = db.Column(db.Text)
     jurisdiction = db.Column(db.Enum(Jurisdiction))
+    units = db.relationship('Unit', backref='agency')
     # total_officers = db.Column(db.Integer)
 
     officer_association = db.relationship("Employment", back_populates="agency")

--- a/backend/database/models/agency.py
+++ b/backend/database/models/agency.py
@@ -1,6 +1,6 @@
-from ..core import db, CrudMixin
 from enum import Enum
 from sqlalchemy.ext.associationproxy import association_proxy
+from ..core import CrudMixin, db
 
 
 class Jurisdiction(str, Enum):
@@ -20,8 +20,9 @@ class Agency(db.Model, CrudMixin):
     hq_city = db.Column(db.Text)
     hq_zip = db.Column(db.Text)
     jurisdiction = db.Column(db.Enum(Jurisdiction))
-    units = db.relationship('Unit', backref='agency')
     # total_officers = db.Column(db.Integer)
+
+    units = db.relationship("Unit", back_populates="agency")
 
     officer_association = db.relationship("Employment", back_populates="agency")
     officers = association_proxy("officer_association", "officer")

--- a/backend/database/models/agency.py
+++ b/backend/database/models/agency.py
@@ -1,6 +1,6 @@
+from ..core import CrudMixin, db
 from enum import Enum
 from sqlalchemy.ext.associationproxy import association_proxy
-from ..core import CrudMixin, db
 
 
 class Jurisdiction(str, Enum):

--- a/backend/database/models/employment.py
+++ b/backend/database/models/employment.py
@@ -66,6 +66,7 @@ def get_highest_rank(records: list[Employment]):
 
 def merge_employment_records(
         records: list[Employment],
+        unit: str = None,
         currently_employed: bool = None
         ):
     """
@@ -85,15 +86,17 @@ def merge_employment_records(
     """
     earliest_employment, latest_employment = get_employment_range(records)
     highest_rank = get_highest_rank(records)
+    if unit is None:
+        unit = records[0].unit
     if currently_employed is None:
         currently_employed = records[0].currently_employed
     return Employment(
         officer_id=records[0].officer_id,
         agency_id=records[0].agency_id,
-        unit_id=records[0].unit_id,
         badge_number=records[0].badge_number,
         earliest_employment=earliest_employment,
         latest_employment=latest_employment,
+        unit=unit,
         highest_rank=highest_rank,
         currently_employed=currently_employed,
     )

--- a/backend/database/models/employment.py
+++ b/backend/database/models/employment.py
@@ -66,7 +66,6 @@ def get_highest_rank(records: list[Employment]):
 
 def merge_employment_records(
         records: list[Employment],
-        unit: str = None,
         currently_employed: bool = None
         ):
     """
@@ -86,17 +85,15 @@ def merge_employment_records(
     """
     earliest_employment, latest_employment = get_employment_range(records)
     highest_rank = get_highest_rank(records)
-    if unit is None:
-        unit = records[0].unit
     if currently_employed is None:
         currently_employed = records[0].currently_employed
     return Employment(
         officer_id=records[0].officer_id,
         agency_id=records[0].agency_id,
+        unit_id=records[0].unit_id,
         badge_number=records[0].badge_number,
         earliest_employment=earliest_employment,
         latest_employment=latest_employment,
-        unit=unit,
         highest_rank=highest_rank,
         currently_employed=currently_employed,
     )

--- a/backend/database/models/employment.py
+++ b/backend/database/models/employment.py
@@ -29,7 +29,7 @@ class Employment(db.Model, CrudMixin):
 
     officer = db.relationship("Officer", back_populates="agency_association")
     agency = db.relationship("Agency", back_populates="officer_association")
-    unit = db.relationship("Unit", backref="unit_association")
+    unit = db.relationship("Unit", back_populates="officer_association")
 
     def __repr__(self):
         return f"<Employment {self.id}>"
@@ -90,10 +90,10 @@ def merge_employment_records(
     return Employment(
         officer_id=records[0].officer_id,
         agency_id=records[0].agency_id,
+        unit_id=records[0].unit_id,
         badge_number=records[0].badge_number,
         earliest_employment=earliest_employment,
         latest_employment=latest_employment,
-        unit=records[0].unit_id,
         highest_rank=highest_rank,
         currently_employed=currently_employed,
     )

--- a/backend/database/models/employment.py
+++ b/backend/database/models/employment.py
@@ -20,15 +20,16 @@ class Employment(db.Model, CrudMixin):
     id = db.Column(db.Integer, primary_key=True)
     officer_id = db.Column(db.Integer, db.ForeignKey("officer.id"))
     agency_id = db.Column(db.Integer, db.ForeignKey("agency.id"))
+    unit_id = db.Column(db.Integer, db.ForeignKey("unit.id"))
     earliest_employment = db.Column(db.Text)
     latest_employment = db.Column(db.Text)
     badge_number = db.Column(db.Text)
-    unit = db.Column(db.Text)
     highest_rank = db.Column(db.Enum(Rank))
     currently_employed = db.Column(db.Boolean)
 
     officer = db.relationship("Officer", back_populates="agency_association")
     agency = db.relationship("Agency", back_populates="officer_association")
+    unit = db.relationship("Unit", backref="unit_association")
 
     def __repr__(self):
         return f"<Employment {self.id}>"
@@ -65,7 +66,6 @@ def get_highest_rank(records: list[Employment]):
 
 def merge_employment_records(
         records: list[Employment],
-        unit: str = None,
         currently_employed: bool = None
         ):
     """
@@ -85,8 +85,6 @@ def merge_employment_records(
     """
     earliest_employment, latest_employment = get_employment_range(records)
     highest_rank = get_highest_rank(records)
-    if unit is None:
-        unit = records[0].unit
     if currently_employed is None:
         currently_employed = records[0].currently_employed
     return Employment(
@@ -95,7 +93,7 @@ def merge_employment_records(
         badge_number=records[0].badge_number,
         earliest_employment=earliest_employment,
         latest_employment=latest_employment,
-        unit=unit,
+        unit=records[0].unit_id,
         highest_rank=highest_rank,
         currently_employed=currently_employed,
     )

--- a/backend/database/models/unit.py
+++ b/backend/database/models/unit.py
@@ -6,8 +6,8 @@ class Unit(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Text)
     agency_id = db.Column(db.Integer, db.ForeignKey('agency.id'))
-    agency = db.relationship("Agency", back_populates="units")
 
+    agency = db.relationship("Agency", back_populates="units")
     officer_association = db.relationship('Employment', back_populates='unit')
     officers = association_proxy('officer_association', 'officer')
 

--- a/backend/database/models/unit.py
+++ b/backend/database/models/unit.py
@@ -14,7 +14,7 @@ class Unit(db.Model, CrudMixin):
     agency_url = db.Column(db.Text)
     officers_url = db.Column(db.Text)
 
-    commander = db.Column(db.Integer, db.ForeignKey('officer.id'))
+    commander_id = db.Column(db.Integer, db.ForeignKey('officer.id'))
     agency_id = db.Column(db.Integer, db.ForeignKey('agency.id'))
 
     agency = db.relationship("Agency", back_populates="units")

--- a/backend/database/models/unit.py
+++ b/backend/database/models/unit.py
@@ -1,0 +1,15 @@
+from ..core import db
+from sqlalchemy.ext.associationproxy import association_proxy
+
+
+class Unit(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.Text)
+    agency_id = db.Column(db.Integer, db.ForeignKey('agency.id'))
+    agency = db.relationship("Agency", back_populates="units")
+
+    officer_association = db.relationship('Employment', back_populates='unit')
+    officers = association_proxy('officer_association', 'officer')
+
+    def __repr__(self):
+        return f"<Unit {self.name}>"

--- a/backend/database/models/unit.py
+++ b/backend/database/models/unit.py
@@ -1,8 +1,8 @@
-from ..core import db
+from ..core import CrudMixin, db
 from sqlalchemy.ext.associationproxy import association_proxy
 
 
-class Unit(db.Model):
+class Unit(db.Model, CrudMixin):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Text)
     agency_id = db.Column(db.Integer, db.ForeignKey('agency.id'))

--- a/backend/database/models/unit.py
+++ b/backend/database/models/unit.py
@@ -5,6 +5,16 @@ from sqlalchemy.ext.associationproxy import association_proxy
 class Unit(db.Model, CrudMixin):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Text)
+    website_url = db.Column(db.Text)
+    phone = db.Column(db.Text)
+    email = db.Column(db.Text)
+    description = db.Column(db.Text)
+    address = db.Column(db.Text)
+    zip = db.Column(db.Text)
+    agency_url = db.Column(db.Text)
+    officers_url = db.Column(db.Text)
+
+    commander = db.Column(db.Integer, db.ForeignKey('officer.id'))
     agency_id = db.Column(db.Integer, db.ForeignKey('agency.id'))
 
     agency = db.relationship("Agency", back_populates="units")

--- a/backend/routes/agencies.py
+++ b/backend/routes/agencies.py
@@ -231,7 +231,6 @@ def add_officer_to_agency(agency_id: int):
                     employment.agency_id = agency_id
                     employment = merge_employment_records(
                         employments.all() + [employment],
-                        unit=record.unit,
                         currently_employed=record.currently_employed
                     )
 

--- a/backend/routes/officers.py
+++ b/backend/routes/officers.py
@@ -304,7 +304,6 @@ def update_employment(officer_id: int):
                     employment.officer_id = officer_id
                     employment = merge_employment_records(
                         employments.all() + [employment],
-                        unit=record.unit,
                         currently_employed=record.currently_employed
                     )
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -14,6 +14,7 @@ from .database.models.action import Action
 from .database.models.partner import Partner, PartnerMember, MemberRole
 from .database.models.incident import Incident, SourceDetails
 from .database.models.agency import Agency, Jurisdiction
+from .database.models.unit import Unit
 from .database.models.officer import Officer, StateID
 from .database.models.employment import Employment
 from .database.models.accusation import Accusation

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -270,6 +270,7 @@ class CreateUnitSchema(_BaseCreateUnitSchema, _UnitMixin):
     zip: Optional[str]
     agency_url: Optional[str]
     officers_url: Optional[str]
+    commander_id: int
     agency_id: int
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -129,6 +129,7 @@ _agency_list_attributes = [
 ]
 
 _unit_list_attributes = [
+    'agency',
     'officer_association',
     'officers'
 ]
@@ -181,6 +182,16 @@ class _AgencyMixin(BaseModel):
     def none_to_list(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         values = {**values}  # convert mappings to base dict type.
         for i in _agency_list_attributes:
+            if not values.get(i):
+                values[i] = []
+        return values
+
+
+class _UnitMixin(BaseModel):
+    @root_validator(pre=True)
+    def none_to_list(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        values = {**values}  # convert mappings to base dict type.
+        for i in _unit_list_attributes:
             if not values.get(i):
                 values[i] = []
         return values
@@ -251,6 +262,14 @@ class CreateAgencySchema(_BaseCreateAgencySchema, _AgencyMixin):
 
 class CreateUnitSchema(_BaseCreateUnitSchema, _UnitMixin):
     name: str
+    website_url: Optional[str]
+    phone: Optional[str]
+    email: Optional[str]
+    description: Optional[str]
+    address: Optional[str]
+    zip: Optional[str]
+    agency_url: Optional[str]
+    officers_url: Optional[str]
     agency_id: int
 
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -128,6 +128,11 @@ _agency_list_attributes = [
     'officers'
 ]
 
+_unit_list_attributes = [
+    'officer_association',
+    'officers'
+]
+
 _partner_list_attrs = ["reported_incidents"]
 
 
@@ -189,7 +194,7 @@ _BaseCreatePartnerSchema = schema_create(Partner)
 _BaseCreateIncidentSchema = schema_create(Incident)
 _BaseCreateOfficerSchema = schema_create(Officer)
 _BaseCreateAgencySchema = schema_create(Agency)
-CreateUnitSchema = schema_create(Unit)
+_BaseCreateUnitSchema = schema_create(Unit)
 CreateStateIDSchema = schema_create(StateID)
 CreateEmploymentSchema = schema_create(Employment)
 CreateAccusationSchema = schema_create(Accusation)
@@ -242,6 +247,11 @@ class CreateAgencySchema(_BaseCreateAgencySchema, _AgencyMixin):
     hq_address: Optional[str]
     hq_city: Optional[str]
     hq_zip: Optional[str]
+
+
+class CreateUnitSchema(_BaseCreateUnitSchema, _UnitMixin):
+    name: str
+    agency_id: int
 
 
 AddMemberSchema = sqlalchemy_to_pydantic(
@@ -302,7 +312,7 @@ class AgencySchema(_BaseAgencySchema, _AgencyMixin):
 
 
 class UnitSchema(_BaseUnitSchema):
-    pass
+    officer_association: List[CreateEmploymentSchema]
 
 
 class PartnerSchema(_BasePartnerSchema, _PartnerMixin):
@@ -406,6 +416,18 @@ def agency_to_orm(agency: CreateAgencySchema) -> Agency:
 
 def agency_orm_to_json(agency: Agency) -> dict:
     return AgencySchema.from_orm(agency).dict(
+        exclude_none=True,
+    )
+
+
+def unit_to_orm(unit: CreateUnitSchema) -> Unit:
+    """Convert the JSON unit into an ORM instance"""
+    orm_attrs = unit.dict()
+    return Unit(**orm_attrs)
+
+
+def unit_orm_to_json(unit: Unit) -> dict:
+    return UnitSchema.from_orm(unit).dict(
         exclude_none=True,
     )
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -123,6 +123,7 @@ _officer_list_attributes = [
 ]
 
 _agency_list_attributes = [
+    'units',
     'officer_association',
     'officers'
 ]
@@ -188,6 +189,7 @@ _BaseCreatePartnerSchema = schema_create(Partner)
 _BaseCreateIncidentSchema = schema_create(Incident)
 _BaseCreateOfficerSchema = schema_create(Officer)
 _BaseCreateAgencySchema = schema_create(Agency)
+CreateUnitSchema = schema_create(Unit)
 CreateStateIDSchema = schema_create(StateID)
 CreateEmploymentSchema = schema_create(Employment)
 CreateAccusationSchema = schema_create(Accusation)
@@ -256,6 +258,7 @@ _BaseIncidentSchema = schema_get(Incident)
 _BaseOfficerSchema = schema_get(Officer)
 _BasePartnerMemberSchema = schema_get(PartnerMember)
 _BaseAgencySchema = schema_get(Agency)
+_BaseUnitSchema = schema_get(Unit)
 VictimSchema = schema_get(Victim)
 PerpetratorSchema = schema_get(Perpetrator)
 TagSchema = schema_get(Tag)
@@ -294,7 +297,12 @@ class OfficerSchema(_BaseOfficerSchema, _OfficerMixin):
 
 
 class AgencySchema(_BaseAgencySchema, _AgencyMixin):
+    units: List[CreateUnitSchema]
     officer_association: List[CreateEmploymentSchema]
+
+
+class UnitSchema(_BaseUnitSchema):
+    pass
 
 
 class PartnerSchema(_BasePartnerSchema, _PartnerMixin):


### PR DESCRIPTION
Converted the unit property, in the Agency Model, into its own Unit Model.
[See issue here](https://github.com/codeforboston/police-data-trust/issues/387)

### Completed
- Created new Unit Model
- Established Unit as a child of agency
- Established an association between Unit and Employment object
- Updated Employment Model's merge_employment_records to account for Unit model
- Updated agencies and officers endpoints to reflect change to merge_employment_records
- Updated schema to include Unit model

### To do next
- Create endpoint for Unit
- Create tests for Unit