### PR TITLE
Replaced deprecated "id" attribute with "uid"

### DIFF
--- a/backend/database/models/officer.py
+++ b/backend/database/models/officer.py
@@ -58,4 +58,4 @@ class Officer(StructuredNode, JsonSerializable):
         'backend.database.models.source.Source', "UPDATED_BY", model=Citation)
 
     def __repr__(self):
-        return f"<Officer {self.id}>"
+        return f"<Officer {self.uid}>"


### PR DESCRIPTION
In Officer model. As noted here https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-id and in a very persistent error message.