### PR TITLE
Adds /complaints routes to the backend

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,6 +31,20 @@ jobs:
         sudo apt-get install python3-dev libpq-dev
         python -m pip install --upgrade pip
         python -m pip install -r requirements/dev_unix.txt
+    - name: Seed Neo4j Test DB
+      shell: bash
+      run: |
+        CONTAINER_ID=$(docker ps \
+          --filter ancestor=neo4j:5.23-community \
+          --format "{{.ID}}")
+        until docker exec $CONTAINER_ID \
+          bin/cypher-shell -u neo4j -p test_pwd "RETURN 1"; do
+          echo "Waiting for Neo4j to wake up…"
+          sleep 1
+        done
+        docker exec $CONTAINER_ID \
+          bin/cypher-shell -u neo4j -p test_pwd \
+          "MERGE (n:TestMarker {name:'TEST_DATABASE'});"        
     - name: Check style
       run: flake8 backend/
     - name: Run tests

--- a/backend/api.py
+++ b/backend/api.py
@@ -9,7 +9,7 @@ from backend.config import get_config_from_env
 from backend.auth import jwt, refresh_token
 from backend.schemas import spec
 from backend.routes.sources import bp as sources_bp
-# from backend.routes.incidents import bp as incidents_bp
+from backend.routes.complaints import bp as complaints_bp
 from backend.routes.officers import bp as officers_bp
 from backend.routes.agencies import bp as agencies_bp
 from backend.routes.auth import bp as auth_bp
@@ -171,7 +171,7 @@ def register_commands(app: Flask):
 
 def register_routes(app: Flask):
     app.register_blueprint(sources_bp)
-    # app.register_blueprint(incidents_bp)
+    app.register_blueprint(complaints_bp)
     app.register_blueprint(auth_bp)
     app.register_blueprint(healthcheck_bp)
     app.register_blueprint(officers_bp)

--- a/backend/database/models/civilian.py
+++ b/backend/database/models/civilian.py
@@ -5,9 +5,10 @@ from neomodel import (
     IntegerProperty,
     RelationshipTo
 )
+from backend.schemas import JsonSerializable
 
 
-class Civilian(StructuredNode):
+class Civilian(StructuredNode, JsonSerializable):
     age = IntegerProperty()
     race = StringProperty()
     gender = StringProperty()

--- a/backend/database/models/civilian.py
+++ b/backend/database/models/civilian.py
@@ -6,12 +6,14 @@ from neomodel import (
     RelationshipTo
 )
 from backend.schemas import JsonSerializable
+from backend.database.models.types.enums import Ethnicity, Gender
 
 
 class Civilian(StructuredNode, JsonSerializable):
     age = IntegerProperty()
-    race = StringProperty()
-    gender = StringProperty()
+    age_range = StringProperty()
+    ethnicity = StringProperty(choices=Ethnicity.choices())
+    gender = StringProperty(choices=Gender.choices())
 
     # Relationships
     complaints = RelationshipTo(

--- a/backend/database/models/complaint.py
+++ b/backend/database/models/complaint.py
@@ -72,10 +72,10 @@ class Complaint(StructuredNode, JsonSerializable):
     source_org = RelationshipTo(
         "backend.database.models.source.Source", "HAS_SOURCE", model=ComplaintSourceRel)
     location = RelationshipTo("Location", "OCCURRED_AT")
-    civilian_witnesses = RelationshipFrom(
-        "backend.database.models.civilian.Civilian", "WITNESSED")
-    police_witnesses = RelationshipFrom(
-        "backend.database.models.officer.Officer", "WITNESSED")
+    civilian_witnesses = RelationshipTo(
+        "backend.database.models.civilian.Civilian", "WITNESSED_BY")
+    police_witnesses = RelationshipTo(
+        "backend.database.models.officer.Officer", "WITNESSED_BY")
     attachments = RelationshipTo(
         "backend.database.models.attachment.Attachment", "ATTACHED_TO")
     allegations = RelationshipTo("Allegation", "ALLEGED")
@@ -116,7 +116,7 @@ class Investigation(StructuredNode, JsonSerializable):
     end_date = DateProperty()
 
     # Relationships
-    investigator = RelationshipFrom(
+    investigator = RelationshipTo(
         "backend.database.models.officer.Officer", "LED_BY")
     complaint = RelationshipFrom("Complaint", "EXAMINED_BY")
 

--- a/backend/database/models/complaint.py
+++ b/backend/database/models/complaint.py
@@ -80,7 +80,8 @@ class Complaint(StructuredNode, JsonSerializable):
 
     # Relationships
     source_org = RelationshipTo(
-        "backend.database.models.source.Source", "HAS_SOURCE", model=ComplaintSourceRel)
+        "backend.database.models.source.Source",
+        "HAS_SOURCE", model=ComplaintSourceRel)
     location = RelationshipTo("Location", "OCCURRED_AT", cardinality=One)
     civilian_witnesses = RelationshipTo(
         "backend.database.models.civilian.Civilian", "WITNESSED_BY")
@@ -111,9 +112,12 @@ class Allegation(StructuredNode, JsonSerializable):
     outcome = StringProperty()
 
     # Relationships
-    complainant = RelationshipTo("backend.database.models.civilian.Civilian", "REPORTED_BY")
-    accused = RelationshipFrom("backend.database.models.officer.Officer", "ACCUSED_OF")
-    complaint = RelationshipFrom("backend.database.models.complaint.Complaint", "ALLEGED")
+    complainant = RelationshipTo(
+        "backend.database.models.civilian.Civilian", "REPORTED_BY")
+    accused = RelationshipFrom(
+        "backend.database.models.officer.Officer", "ACCUSED_OF")
+    complaint = RelationshipFrom(
+        "backend.database.models.complaint.Complaint", "ALLEGED")
 
     def __repr__(self):
         """Represent instance as a unique string."""

--- a/backend/database/models/complaint.py
+++ b/backend/database/models/complaint.py
@@ -60,6 +60,15 @@ class Location(StructuredNode, JsonSerializable):
 
 
 class Complaint(StructuredNode, JsonSerializable):
+    __property_order__ = [
+        "uid", "record_id", "category",
+        "incident_date", "recieved_date",
+        "closed_date", "reason_for_contact",
+        "outcome_of_contact"
+    ]
+
+    __hidden_properties__ = ["citations"]
+
     uid = UniqueIdProperty()
     record_id = StringProperty()
     category = StringProperty()

--- a/backend/database/models/complaint.py
+++ b/backend/database/models/complaint.py
@@ -51,7 +51,7 @@ class ComplaintSourceRel(StructuredRel, JsonSerializable):
 
 class Location(StructuredNode, JsonSerializable):
     location_type = StringProperty()
-    loocation_description = StringProperty()
+    location_description = StringProperty()
     address = StringProperty()
     city = StringProperty()
     state = StringProperty()
@@ -63,7 +63,7 @@ class Location(StructuredNode, JsonSerializable):
 class Complaint(StructuredNode, JsonSerializable):
     __property_order__ = [
         "uid", "record_id", "category",
-        "incident_date", "recieved_date",
+        "incident_date", "received_date",
         "closed_date", "reason_for_contact",
         "outcome_of_contact"
     ]
@@ -74,7 +74,7 @@ class Complaint(StructuredNode, JsonSerializable):
     record_id = StringProperty()
     category = StringProperty()
     incident_date = DateProperty()
-    recieved_date = DateProperty()
+    received_date = DateProperty()
     closed_date = DateProperty()
     reason_for_contact = StringProperty()
     outcome_of_contact = StringProperty()

--- a/backend/database/models/complaint.py
+++ b/backend/database/models/complaint.py
@@ -127,8 +127,12 @@ class Investigation(StructuredNode, JsonSerializable):
 
 class Penalty(StructuredNode, JsonSerializable):
     uid = UniqueIdProperty()
-    description = StringProperty()
+    penalty = StringProperty()
     date_assessed = DateProperty()
+    crb_plea = StringProperty()
+    crb_case_status = StringProperty()
+    crb_disposition = StringProperty()
+    agency_disposition = StringProperty()
 
     # Relationships
     officer = RelationshipFrom(

--- a/backend/database/models/complaint.py
+++ b/backend/database/models/complaint.py
@@ -9,7 +9,8 @@ from neomodel import (
     RelationshipFrom,
     DateProperty,
     UniqueIdProperty,
-    One
+    One,
+    ZeroOrOne
 )
 
 
@@ -113,11 +114,14 @@ class Allegation(StructuredNode, JsonSerializable):
 
     # Relationships
     complainant = RelationshipTo(
-        "backend.database.models.civilian.Civilian", "REPORTED_BY")
+        "backend.database.models.civilian.Civilian",
+        "REPORTED_BY", cardinality=ZeroOrOne)
     accused = RelationshipFrom(
-        "backend.database.models.officer.Officer", "ACCUSED_OF")
+        "backend.database.models.officer.Officer",
+        "ACCUSED_OF", cardinality=ZeroOrOne)
     complaint = RelationshipFrom(
-        "backend.database.models.complaint.Complaint", "ALLEGED")
+        "backend.database.models.complaint.Complaint",
+        "ALLEGED", cardinality=One)
 
     def __repr__(self):
         """Represent instance as a unique string."""
@@ -131,7 +135,8 @@ class Investigation(StructuredNode, JsonSerializable):
 
     # Relationships
     investigator = RelationshipTo(
-        "backend.database.models.officer.Officer", "LED_BY")
+        "backend.database.models.officer.Officer",
+        "LED_BY", cardinality=ZeroOrOne)
     complaint = RelationshipFrom("Complaint", "EXAMINED_BY")
 
     def __repr__(self):
@@ -150,8 +155,9 @@ class Penalty(StructuredNode, JsonSerializable):
 
     # Relationships
     officer = RelationshipFrom(
-        "backend.database.models.officer.Officer", "RECEIVED")
-    complaint = RelationshipFrom("Complaint", "RESULTS_IN")
+        "backend.database.models.officer.Officer",
+        "RECEIVED", cardinality=One)
+    complaint = RelationshipFrom("Complaint", "RESULTS_IN", cardinality=One)
 
     def __repr__(self):
         """Represent instance as a unique string."""

--- a/backend/database/models/complaint.py
+++ b/backend/database/models/complaint.py
@@ -1,5 +1,6 @@
 """Define the Classes for Complaints."""
 from backend.schemas import JsonSerializable, PropertyEnum
+from backend.database.models.source import Citation
 from neomodel import (
     StructuredNode,
     StructuredRel,
@@ -19,33 +20,42 @@ class RecordType(str, PropertyEnum):
 
 
 # Neo4j Models
-class BaseSourceRel(StructuredRel, JsonSerializable):
+class ComplaintSourceRel(StructuredRel, JsonSerializable):
+    uid = UniqueIdProperty()
     record_type = StringProperty(
         choices=RecordType.choices(),
         required=True
     )
+    date_published = DateProperty()
 
-
-class LegalSourceRel(BaseSourceRel):
+    # Legal Source Properties
     court = StringProperty()
     judge = StringProperty()
     docket_number = StringProperty()
-    date_of_action = DateProperty()
+    case_event_date = DateProperty()
 
-
-class NewsSourceRel(BaseSourceRel):
+    # News Source Properties
     publication_name = StringProperty()
-    publication_date = DateProperty()
     publication_url = StringProperty()
     author = StringProperty()
     author_url = StringProperty()
     author_email = StringProperty()
 
-
-class GovernmentSourceRel(BaseSourceRel):
+    # Government Source Properties
     reporting_agency = StringProperty()
     reporting_agency_url = StringProperty()
     reporting_agency_email = StringProperty()
+
+
+class Location(StructuredNode, JsonSerializable):
+    location_type = StringProperty()
+    loocation_description = StringProperty()
+    address = StringProperty()
+    city = StringProperty()
+    state = StringProperty()
+    zip = StringProperty()
+    responsibility = StringProperty()
+    responsibility_type = StringProperty()
 
 
 class Complaint(StructuredNode, JsonSerializable):
@@ -59,49 +69,55 @@ class Complaint(StructuredNode, JsonSerializable):
     outcome_of_contact = StringProperty()
 
     # Relationships
-    source_org = RelationshipFrom("Source", "REPORTED", model=BaseSourceRel)
+    source_org = RelationshipTo(
+        "backend.database.models.source.Source", "HAS_SOURCE", model=ComplaintSourceRel)
     location = RelationshipTo("Location", "OCCURRED_AT")
-    civlian_witnesses = RelationshipFrom("Civilian", "WITNESSED")
-    police_witnesses = RelationshipFrom("Officer", "WITNESSED")
-    attachments = RelationshipTo("Attachment", "ATTACHED_TO")
+    civilian_witnesses = RelationshipFrom(
+        "backend.database.models.civilian.Civilian", "WITNESSED")
+    police_witnesses = RelationshipFrom(
+        "backend.database.models.officer.Officer", "WITNESSED")
+    attachments = RelationshipTo(
+        "backend.database.models.attachment.Attachment", "ATTACHED_TO")
     allegations = RelationshipTo("Allegation", "ALLEGED")
     investigations = RelationshipTo("Investigation", "EXAMINED_BY")
     penalties = RelationshipTo("Penalty", "RESULTS_IN")
-    civilian_review_board = RelationshipFrom("CivilianReviewBoard", "REVIEWED")
+    citations = RelationshipTo(
+        'backend.database.models.source.Source', "UPDATED_BY", model=Citation)
 
     def __repr__(self):
         """Represent instance as a unique string."""
         return f"<Complaint {self.uid}>"
 
 
-class Allegation(StructuredNode):
+class Allegation(StructuredNode, JsonSerializable):
     uid = UniqueIdProperty()
     record_id = StringProperty()
     allegation = StringProperty()
     type = StringProperty()
-    subsype = StringProperty()
+    subtype = StringProperty()
     recommended_finding = StringProperty()
     recommended_outcome = StringProperty()
     finding = StringProperty()
     outcome = StringProperty()
 
     # Relationships
-    complainant = RelationshipFrom("Civilian", "COMPLAINED_OF")
-    accused = RelationshipFrom("Officer", "ACCUSED_OF")
-    complaint = RelationshipFrom("Complaint", "ALLEGED")
+    complainant = RelationshipTo("backend.database.models.civilian.Civilian", "REPORTED_BY")
+    accused = RelationshipFrom("backend.database.models.officer.Officer", "ACCUSED_OF")
+    complaint = RelationshipFrom("backend.database.models.complaint.Complaint", "ALLEGED")
 
     def __repr__(self):
         """Represent instance as a unique string."""
         return f"<Allegation {self.uid}>"
 
 
-class Investigation(StructuredNode):
+class Investigation(StructuredNode, JsonSerializable):
     uid = UniqueIdProperty()
     start_date = DateProperty()
     end_date = DateProperty()
 
     # Relationships
-    investigator = RelationshipFrom("Officer", "LED_BY")
+    investigator = RelationshipFrom(
+        "backend.database.models.officer.Officer", "LED_BY")
     complaint = RelationshipFrom("Complaint", "EXAMINED_BY")
 
     def __repr__(self):
@@ -109,13 +125,14 @@ class Investigation(StructuredNode):
         return f"<Investigation {self.uid}>"
 
 
-class Penalty(StructuredNode):
+class Penalty(StructuredNode, JsonSerializable):
     uid = UniqueIdProperty()
     description = StringProperty()
     date_assessed = DateProperty()
 
     # Relationships
-    officer = RelationshipFrom("Officer", "RECEIVED")
+    officer = RelationshipFrom(
+        "backend.database.models.officer.Officer", "RECEIVED")
     complaint = RelationshipFrom("Complaint", "RESULTS_IN")
 
     def __repr__(self):

--- a/backend/database/models/complaint.py
+++ b/backend/database/models/complaint.py
@@ -8,7 +8,8 @@ from neomodel import (
     RelationshipTo,
     RelationshipFrom,
     DateProperty,
-    UniqueIdProperty
+    UniqueIdProperty,
+    One
 )
 
 
@@ -54,8 +55,8 @@ class Location(StructuredNode, JsonSerializable):
     city = StringProperty()
     state = StringProperty()
     zip = StringProperty()
-    responsibility = StringProperty()
-    responsibility_type = StringProperty()
+    administrative_area = StringProperty()
+    administrative_area_type = StringProperty()
 
 
 class Complaint(StructuredNode, JsonSerializable):
@@ -71,7 +72,7 @@ class Complaint(StructuredNode, JsonSerializable):
     # Relationships
     source_org = RelationshipTo(
         "backend.database.models.source.Source", "HAS_SOURCE", model=ComplaintSourceRel)
-    location = RelationshipTo("Location", "OCCURRED_AT")
+    location = RelationshipTo("Location", "OCCURRED_AT", cardinality=One)
     civilian_witnesses = RelationshipTo(
         "backend.database.models.civilian.Civilian", "WITNESSED_BY")
     police_witnesses = RelationshipTo(

--- a/backend/database/models/source.py
+++ b/backend/database/models/source.py
@@ -90,7 +90,7 @@ class SourceMember(StructuredRel, JsonSerializable):
 
     def is_administrator(self):
         return self.role == MemberRole.ADMIN
-    
+
     def may_publish(self):
         return self.role_enum.get_value() <= MemberRole.PUBLISHER.get_value()
 

--- a/backend/database/models/source.py
+++ b/backend/database/models/source.py
@@ -9,7 +9,6 @@ from neomodel import (
     UniqueIdProperty, BooleanProperty,
     EmailProperty
 )
-from backend.database.models.complaint import BaseSourceRel
 
 
 class MemberRole(str, PropertyEnum):
@@ -133,7 +132,7 @@ class Source(StructuredNode, JsonSerializable):
         "IS_MEMBER", model=SourceMember)
     complaints = RelationshipTo(
         "backend.database.models.complaint.Complaint",
-        "REPORTED", model=BaseSourceRel)
+        "REPORTED")
     invitations = RelationshipTo(
         "Invitation", "HAS_PENDING_INVITATION")
     staged_invitations = RelationshipTo(

--- a/backend/database/models/source.py
+++ b/backend/database/models/source.py
@@ -90,6 +90,9 @@ class SourceMember(StructuredRel, JsonSerializable):
 
     def is_administrator(self):
         return self.role == MemberRole.ADMIN
+    
+    def may_publish(self):
+        return self.role_enum.get_value() <= MemberRole.PUBLISHER.get_value()
 
     def get_default_role():
         return MemberRole.SUBSCRIBER
@@ -101,7 +104,7 @@ class SourceMember(StructuredRel, JsonSerializable):
     def __repr__(self):
         """Represent instance as a unique string."""
         return f"<SourceMember( \
-        id={self.uid}>"
+        uid={self.uid}>"
 
 
 class Citation(StructuredRel, JsonSerializable):

--- a/backend/database/models/user.py
+++ b/backend/database/models/user.py
@@ -61,7 +61,7 @@ class User(StructuredNode, JsonSerializable):
         "MEMBER_OF_SOURCE", model=SourceMember)
     received_invitations = Relationship(
         'backend.database.models.source.Invitation',
-        "RECIEVED")
+        "RECEIVED")
     extended_invitations = Relationship(
         'backend.database.models.source.Invitation',
         "EXTENDED")

--- a/backend/routes/agencies.py
+++ b/backend/routes/agencies.py
@@ -115,6 +115,14 @@ def update_agency(agency_uid: str):
         return agency.to_json()
     except Exception as e:
         abort(400, description=str(e))
+    
+    try:
+        Agency.link_location(
+            agency, state=agency.hq_state, city=agency.hq_city)
+    except Exception as e:
+        logging.error(f"Error linking location {agency.name}: {e}")
+        print(f"Error linking location {agency.name}: {e}")
+        return
 
 
 # Delete agency profile

--- a/backend/routes/agencies.py
+++ b/backend/routes/agencies.py
@@ -115,14 +115,6 @@ def update_agency(agency_uid: str):
         return agency.to_json()
     except Exception as e:
         abort(400, description=str(e))
-    
-    try:
-        Agency.link_location(
-            agency, state=agency.hq_state, city=agency.hq_city)
-    except Exception as e:
-        logging.error(f"Error linking location {agency.name}: {e}")
-        print(f"Error linking location {agency.name}: {e}")
-        return
 
 
 # Delete agency profile

--- a/backend/routes/complaints.py
+++ b/backend/routes/complaints.py
@@ -189,11 +189,6 @@ def create_investigation(
             f"for Complaint {complaint.uid}")
     except Exception as e:
         logging.error(f"Error creating investigation: {e}")
-        if investigation:
-            # If the investigation was created but failed to connect, delete it
-            logging.error(
-                f"Deleting investigation {investigation.uid} due to error")
-            investigation.delete()
         return AttributeError(
             f"Failed to create investigation: {e}")
     if investigator_uid:
@@ -433,6 +428,7 @@ def get_all_complaints():
 @jwt_required()
 @min_role_required(UserRole.CONTRIBUTOR)
 @validate_request(UpdateComplaint)
+@edit_permission_required()
 def update_complaint(complaint_uid: str):
     """Update a complaint record.
     """
@@ -641,7 +637,7 @@ def delete_complaint_allegation(complaint_uid: str, allegation_uid: str):
                 "allegation_uid": uid
             },
         )
-        return {"message": "Allegation deleted successfully"}
+        return {"message": "Allegation deleted successfully"}, 204
     except Exception as e:
         abort(400, description=str(e))
 
@@ -795,7 +791,7 @@ def delete_complaint_investigation(complaint_uid: str, investigation_uid: str):
                 "investigation_uid": uid
             },
         )
-        return {"message": "Investigation deleted successfully"}
+        return {"message": "Investigation deleted successfully"}, 204
     except Exception as e:
         abort(400, description=str(e))
 
@@ -945,6 +941,6 @@ def delete_complaint_penalty(complaint_uid: str, penalty_uid: str):
                 "penalty_uid": uid
             },
         )
-        return {"message": "Penalty deleted successfully"}
+        return {"message": "Penalty deleted successfully"}, 204
     except Exception as e:
         abort(400, description=str(e))

--- a/backend/routes/complaints.py
+++ b/backend/routes/complaints.py
@@ -1,0 +1,137 @@
+import logging
+from typing import Optional, List
+
+from backend.auth.jwt import min_role_required
+from backend.mixpanel.mix import track_to_mp
+from backend.schemas import validate_request, ordered_jsonify, paginate_results
+from backend.database.models.user import UserRole, User
+from backend.database.models.complaint import Complaint
+from .tmp.pydantic.complaints import CreateComplaint, UpdateComplaint
+from flask import Blueprint, abort, request
+from flask_jwt_extended import get_jwt
+from flask_jwt_extended.view_decorators import jwt_required
+from pydantic import BaseModel
+from neomodel import db
+
+
+bp = Blueprint("complaint_routes", __name__, url_prefix="/api/v1/complaints")
+
+
+# Create a complaint
+@bp.route("/", methods=["POST"])
+@jwt_required()
+@min_role_required(UserRole.CONTRIBUTOR)
+@validate_request(CreateComplaint)
+def create_complaint():
+    """Create a complaint.
+    """
+    logger = logging.getLogger("create_complaint")
+    body: CreateComplaint = request.validated_body
+    jwt_decoded = get_jwt()
+    current_user = User.get(jwt_decoded["sub"])
+
+    # try:
+    complaint = Complaint.from_dict(body.model_dump())
+    # except Exception as e:
+    #     abort(400, description=str(e))
+
+    logger.info(f"Complaint {complaint.uid} created by User {current_user.uid}")
+    track_to_mp(
+        request,
+        "create_complaint",
+        {
+            "complaint_uid": complaint.uid
+        },
+    )
+    return complaint.to_json()
+
+
+# Get a complaint record
+@bp.route("/<complaint_uid>", methods=["GET"])
+@jwt_required()
+@min_role_required(UserRole.PUBLIC)
+def get_complaint(complaint_uid: int):
+    """Get a complaint record.
+    """
+    c = Complaint.nodes.get_or_none(uid=complaint_uid)
+    if c is None:
+        abort(404, description="Complaint not found")
+    return c.to_json()
+
+
+
+# Get all complaints
+@bp.route("/", methods=["GET"])
+@jwt_required()
+@min_role_required(UserRole.PUBLIC)
+def get_all_complaints():
+    """Get all complaints.
+    Accepts Query Parameters for pagination:
+    per_page: number of results per page
+    page: page number
+    """
+    logger = logging.getLogger("get_all_complaints")
+    args = request.args
+    q_page = args.get("page", 1, type=int)
+    q_per_page = args.get("per_page", 20, type=int)
+
+    all_complaints = Complaint.nodes.all()
+    results = paginate_results(all_complaints, q_page, q_per_page)
+    if not results:
+        abort(404, description="No complaints found")
+    return ordered_jsonify(results), 200
+
+
+# Update a complaint record
+@bp.route("/<complaint_uid>", methods=["PUT"])
+@jwt_required()
+@min_role_required(UserRole.CONTRIBUTOR)
+@validate_request(UpdateComplaint)
+def update_complaint(complaint_uid: str):
+    """Update a complaint record.
+    """
+    body: UpdateComplaint = request.validated_body
+    c = Complaint.nodes.get_or_none(uid=complaint_uid)
+    if c is None:
+        abort(404, description="Complaint not found")
+
+    try:
+        c = Complaint.from_dict(body.model_dump(), complaint_uid)
+        c.refresh()
+    except Exception as e:
+        abort(400, description=str(e))
+
+    track_to_mp(
+        request,
+        "update_complaint",
+        {
+            "complaint_uid": c.uid
+        },
+    )
+    return c.to_json()
+
+
+# Delete a complaint record
+@bp.route("/<complaint_uid>", methods=["DELETE"])
+@jwt_required()
+@min_role_required(UserRole.ADMIN)
+def delete_complaint(complaint_uid: str):
+    """Delete a complaint record.
+    Must be an admin to delete a complaint.
+    """
+    c = Complaint.nodes.get_or_none(uid=complaint_uid)
+    if c is None:
+        abort(404, description="Complaint not found")
+    try:
+        uid = c.uid
+        c.delete()
+        track_to_mp(
+            request,
+            "delete_complaint",
+            {
+                "complaint_uid": uid
+            },
+        )
+        return {"message": "Complaint deleted successfully"}
+    except Exception as e:
+        abort(400, description=str(e))

--- a/backend/routes/tmp/pydantic/common.py
+++ b/backend/routes/tmp/pydantic/common.py
@@ -9,7 +9,7 @@ class PaginatedResponse(BaseModel):
     total: Optional[int] = Field(None, description="The total number of items.")
 
 
-class Attachemnt(BaseModel):
+class Attachment(BaseModel):
     type: Optional[str] = Field(None, description="The filetype of attachment.")
     url: Optional[str] = Field(None, description="The URL of the attachment.")
     title: Optional[str] = Field(None, description="The title of the attachment.")

--- a/backend/routes/tmp/pydantic/common.py
+++ b/backend/routes/tmp/pydantic/common.py
@@ -10,12 +10,9 @@ class PaginatedResponse(BaseModel):
 
 
 class Attachment(BaseModel):
-    type: Optional[str] = Field(None, description="The filetype of attachment.")
+    filetype: Optional[str] = Field(None, description="The filetype of attachment.")
     url: Optional[str] = Field(None, description="The URL of the attachment.")
     title: Optional[str] = Field(None, description="The title of the attachment.")
-    description: Optional[str] = Field(
-        None, description="A description of the attachment."
-    )
 
 
 class Article(BaseModel):

--- a/backend/routes/tmp/pydantic/common.py
+++ b/backend/routes/tmp/pydantic/common.py
@@ -1,8 +1,27 @@
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any, Union
+from datetime import date
 
 
 class PaginatedResponse(BaseModel):
     page: Optional[int] = Field(None, description="The current page number.")
     per_page: Optional[int] = Field(None, description="The number of items per page.")
     total: Optional[int] = Field(None, description="The total number of items.")
+
+
+class Attachemnt(BaseModel):
+    type: Optional[str] = Field(None, description="The filetype of attachment.")
+    url: Optional[str] = Field(None, description="The URL of the attachment.")
+    title: Optional[str] = Field(None, description="The title of the attachment.")
+    description: Optional[str] = Field(
+        None, description="A description of the attachment."
+    )
+
+
+class Article(BaseModel):
+    url: Optional[str] = Field(None, description="The URL of the article.")
+    title: Optional[str] = Field(None, description="The title of the article.")
+    publisher: Optional[str] = Field(None, description="The publisher of the article.")
+    publication_date: Optional[date] = Field(
+        None, description="The date of publication of the article."
+    )

--- a/backend/routes/tmp/pydantic/complaints.py
+++ b/backend/routes/tmp/pydantic/complaints.py
@@ -1,0 +1,327 @@
+from datetime import date
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, Field
+
+from .common import Attachemnt
+from backend.database.models.types.enums import Ethnicity, Gender
+
+
+class Location(BaseModel):
+    """Location object"""
+
+    location_type: Optional[str] = Field(
+        None,
+        description="The type of location. For example: Bar or Tavern, "
+        "Street/Highway, etc.",
+    )
+    location_description: Optional[str] = Field(
+        None, description="A written description of the location."
+    )
+    address: Optional[str] = Field(None, description="The address of the location.")
+    city: Optional[str] = Field(None, description="The city the location is in.")
+    state: Optional[str] = Field(None, description="The state the location is in.")
+    zip: Optional[str] = Field(None, description="The zip code of the location.")
+    responsibility: Optional[str] = Field(
+        None,
+        description="The responsibility area this location is assigned "
+        "by the local law enforcement agency.",
+    )
+    responsibility_type: Optional[str] = Field(
+        None,
+        description="The type of responsibility area. For example: Beat, "
+        "Sector, Precinct, etc.",
+    )
+
+
+class Civilian(BaseModel):
+    age: Optional[int] = Field(None, description="Estimated age of the individual.")
+    age_range: Optional[str] = Field(None, description="Age range of the individual.")
+    ethnicity: Optional[Ethnicity] = Field(
+        None, description="The ethnicity of the individual."
+    )
+    gender: Optional[Gender] = Field(None, description="The gender of the individual.")
+
+
+class BaseAllegation(BaseModel):
+    record_id: Optional[str] = Field(
+        None,
+        description="The ID that was given to this allegation by the "
+        "original source of the data.",
+    )
+    complainant: Optional[Civilian] = Field(
+        None,
+        description="Demographic information of the individual "
+        "who filed the complaint.",
+    )
+    allegation: Optional[str] = Field(
+        None, description="The allegation made by the complainant."
+    )
+    type: Optional[str] = Field(None, description="The type of allegation.")
+    sub_type: Optional[str] = Field(None, description="The sub type of the allegation.")
+    recomended_finding: Optional[str] = Field(
+        None, description="The finding recommended by the review board."
+    )
+    recomended_outcome: Optional[str] = Field(
+        None, description="The outcome recommended by the review board."
+    )
+    finding: Optional[str] = Field(None, description="The legal finding.")
+    outcome: Optional[str] = Field(
+        None, description="The final outcome of the allegation."
+    )
+
+
+class CreateAllegation(BaseModel):
+    record_id: Optional[str] = Field(
+        None,
+        description="The ID that was given to this allegation by the "
+        "original source of the data.",
+    )
+    complainant: Optional[Civilian] = Field(
+        None,
+        description="Demographic information of the individual "
+        "who filed the complaint.",
+    )
+    allegation: Optional[str] = Field(
+        None, description="The allegation made by the complainant."
+    )
+    type: Optional[str] = Field(None, description="The type of allegation.")
+    sub_type: Optional[str] = Field(None, description="The sub type of the allegation.")
+    recomended_finding: Optional[str] = Field(
+        None, description="The finding recommended by the review board."
+    )
+    recomended_outcome: Optional[str] = Field(
+        None, description="The outcome recommended by the review board."
+    )
+    finding: Optional[str] = Field(None, description="The legal finding.")
+    outcome: Optional[str] = Field(
+        None, description="The final outcome of the allegation."
+    )
+    perpetrator_uid: Optional[str] = Field(
+        None, description="The UID of the officer the allegation is " "made against."
+    )
+
+
+class CreatePenalty(BaseModel):
+    officer_uid: Optional[str] = Field(
+        None, description="The UID of the officer the penalty is " "associated with."
+    )
+    crb_plea: Optional[str] = Field(
+        None,
+        description="A plea deal agreed by the officer and " "civilian review board.",
+    )
+    crb_case_status: Optional[str] = Field(
+        None, description="The status of the civilian review board's " "case."
+    )
+    crb_disposition: Optional[str] = Field(
+        None, description="The civilian review board's disposition."
+    )
+    agency_disposition: Optional[str] = Field(
+        None, description="The agency's disposition."
+    )
+    penalty: Optional[str] = Field(None, description="A description of the penalty.")
+    date_assesed: Optional[date] = Field(
+        None, description="The date that the penalty was assessed."
+    )
+
+
+class BaseInvestigation(BaseModel):
+    start_date: Optional[str] = Field(
+        None, description="The date the investigation started."
+    )
+    end_date: Optional[str] = Field(
+        None, description="The date the investigation ended."
+    )
+
+
+class CreateInvestigation(BaseInvestigation, BaseModel):
+    start_date: Optional[str] = Field(
+        None, description="The date the investigation started."
+    )
+    end_date: Optional[str] = Field(
+        None, description="The date the investigation ended."
+    )
+    investigator_uid: Optional[str] = Field(
+        None, description="The UID of the officer who performed the " "investigation."
+    )
+
+
+class ReviewBoard(BaseModel):
+    uid: Optional[str] = Field(
+        None, description="Unique identifier for the review board."
+    )
+    name: Optional[str] = Field(None, description="The name of the review board.")
+    city: Optional[str] = Field(
+        None, description="The city the review board is located in."
+    )
+    state: Optional[str] = Field(
+        None, description="The state the review board is located in."
+    )
+    url: Optional[str] = Field(
+        None, description="The website URL for the review board."
+    )
+
+
+class SourceDetails(BaseModel):
+    record_type: str = Field(
+        None, description="The type of record the complaint is associated with."
+    )
+
+
+class LegalAction(BaseModel):
+    record_type: Literal["legal"]
+    court: Optional[str] = Field(
+        None, description="The court the legal action was filed in."
+    )
+    judge: Optional[str] = Field(
+        None, description="The judge who presided over the case."
+    )
+    docket_number: Optional[str] = Field(
+        None, description="The docket number of the case."
+    )
+    date_of_action: Optional[str] = Field(
+        None, description="The date the legal action was filed."
+    )
+
+
+class PersonalAccount(BaseModel):
+    record_type: Literal["personal"]
+
+
+class GovernmentRecord(BaseModel):
+    record_type: Literal["government"]
+    reporting_agency: Optional[str] = Field(
+        None, description="The agency that reported the record."
+    )
+    reporting_agency_url: Optional[str] = Field(
+        None, description="The URL of the agency that reported the " "record."
+    )
+    reporting_agency_email: Optional[str] = Field(
+        None, description="The email of the agency that reported the " "record."
+    )
+
+
+class NewsReport(BaseModel):
+    record_type: Literal["news"]
+    publication_name: Optional[str] = Field(
+        None, description="The name of the publication."
+    )
+    publication_date: Optional[str] = Field(
+        None, description="The date the publication was released."
+    )
+    publication_url: Optional[str] = Field(
+        None, description="The URL of the publication."
+    )
+    author: Optional[str] = Field(None, description="The author of the publication.")
+    author_url: Optional[str] = Field(None, description="The URL of the author.")
+    author_email: Optional[str] = Field(None, description="The email of the author.")
+
+
+class CreateComplaint(BaseModel):
+    record_id: Optional[str] = Field(
+        None,
+        description="The ID that was given to this complaint by the "
+        "original source of the data.",
+    )
+    source_details: Union[
+        LegalAction, PersonalAccount, GovernmentRecord, NewsReport
+    ] = Field(
+        None,
+        description="The source details of the complaint.",
+        discriminator="record_type",
+    )
+    category: Optional[str] = Field(None, description="The category of the complaint.")
+    incident_date: Optional[date] = Field(
+        None, description="The date and time the incident occurred."
+    )
+    received_date: Optional[date] = Field(
+        None,
+        description="The date and time the complaint was received "
+        "by the reporting source.",
+    )
+    closed_date: Optional[date] = Field(
+        None, description="The date and time the complaint was closed."
+    )
+    updated_date: Optional[date] = Field(
+        None, description="The date and time the complaint was last updated."
+    )
+    location: Optional[Dict[str, Any]] = None
+    reason_for_contact: Optional[str] = Field(
+        None, description="The reason for the contact."
+    )
+    outcome_of_contact: Optional[str] = Field(
+        None, description="The outcome of the contact."
+    )
+    civilian_witnesses: Optional[List[Civilian]] = Field(
+        None, description="The civilian witnesses associated with the " "complaint."
+    )
+    attachments: Optional[List[Attachemnt]] = Field(
+        None, description="Documents and multimedia associated with " "the complaint."
+    )
+    civilian_review_board_uid: Optional[str] = Field(
+        None,
+        description="The UID of the civilian review board that reviewed "
+        "the complaint.",
+    )
+    police_witnesses: Optional[List[str]] = Field(
+        None,
+        description="The UID of any police witnesses associated with " "the complaint.",
+    )
+    allegations: Optional[List[CreateAllegation]] = Field(
+        None, description="The allegations associated with the complaint."
+    )
+    investigations: Optional[List[CreateInvestigation]] = Field(
+        None, description="The investigations associated with the " "complaint."
+    )
+    penalties: Optional[List[CreatePenalty]] = Field(
+        None, description="The penalties associated with the complaint."
+    )
+
+
+class UpdateComplaint(BaseModel):
+    category: Optional[str] = Field(None, description="The category of the complaint.")
+    incident_date: Optional[date] = Field(
+        None, description="The date and time the incident occurred."
+    )
+    received_date: Optional[date] = Field(
+        None,
+        description="The date and time the complaint was received "
+        "by the reporting source.",
+    )
+    closed_date: Optional[date] = Field(
+        None, description="The date and time the complaint was closed."
+    )
+    updated_date: Optional[date] = Field(
+        None, description="The date and time the complaint was last updated."
+    )
+    location: Optional[Dict[str, Any]] = None
+    reason_for_contact: Optional[str] = Field(
+        None, description="The reason for the contact."
+    )
+    outcome_of_contact: Optional[str] = Field(
+        None, description="The outcome of the contact."
+    )
+    civilian_witnesses: Optional[List[Civilian]] = Field(
+        None, description="The civilian witnesses associated with the " "complaint."
+    )
+    attachments: Optional[List[Attachemnt]] = Field(
+        None, description="Documents and multimedia associated with " "the complaint."
+    )
+    civilian_review_board_uid: Optional[str] = Field(
+        None,
+        description="The UID of the civilian review board that reviewed "
+        "the complaint.",
+    )
+    police_witnesses: Optional[List[str]] = Field(
+        None,
+        description="The UID of any police witnesses associated with " "the complaint.",
+    )
+    allegations: Optional[List[CreateAllegation]] = Field(
+        None, description="The allegations associated with the complaint."
+    )
+    investigations: Optional[List[CreateInvestigation]] = Field(
+        None, description="The investigations associated with the " "complaint."
+    )
+    penalties: Optional[List[CreatePenalty]] = Field(
+        None, description="The penalties associated with the complaint."
+    )

--- a/backend/routes/tmp/pydantic/complaints.py
+++ b/backend/routes/tmp/pydantic/complaints.py
@@ -42,6 +42,9 @@ class CreateCivilian(BaseModel):
     )
     gender: Optional[Gender] = Field(None, description="The gender of the individual.")
 
+    class Config:
+        use_enum_values = True
+
 
 class CreateAllegation(BaseModel):
     accused_uid: str = Field(
@@ -62,10 +65,10 @@ class CreateAllegation(BaseModel):
     )
     type: Optional[str] = Field(None, description="The type of allegation.")
     subtype: Optional[str] = Field(None, description="The sub type of the allegation.")
-    recomended_finding: Optional[str] = Field(
+    recommended_finding: Optional[str] = Field(
         None, description="The finding recommended by the review board."
     )
-    recomended_outcome: Optional[str] = Field(
+    recommended_outcome: Optional[str] = Field(
         None, description="The outcome recommended by the review board."
     )
     finding: Optional[str] = Field(None, description="The legal finding.")

--- a/backend/routes/tmp/pydantic/complaints.py
+++ b/backend/routes/tmp/pydantic/complaints.py
@@ -44,6 +44,9 @@ class CreateCivilian(BaseModel):
 
 
 class CreateAllegation(BaseModel):
+    accused_uid: str = Field(
+        None, description="The UID of the officer the allegation is made against."
+    )
     record_id: Optional[str] = Field(
         None,
         description="The ID that was given to this allegation by the "
@@ -69,21 +72,19 @@ class CreateAllegation(BaseModel):
     outcome: Optional[str] = Field(
         None, description="The final outcome of the allegation."
     )
-    accused_uid: Optional[str] = Field(
-        None, description="The UID of the officer the allegation is " "made against."
-    )
+
 
 
 class CreatePenalty(BaseModel):
-    officer_uid: Optional[str] = Field(
-        None, description="The UID of the officer the penalty is " "associated with."
+    officer_uid: str = Field(
+        None, description="The UID of the officer the penalty is associated with."
     )
     crb_plea: Optional[str] = Field(
         None,
-        description="A plea deal agreed by the officer and " "civilian review board.",
+        description="A plea deal agreed by the officer and civilian review board.",
     )
     crb_case_status: Optional[str] = Field(
-        None, description="The status of the civilian review board's " "case."
+        None, description="The status of the civilian review board's case."
     )
     crb_disposition: Optional[str] = Field(
         None, description="The civilian review board's disposition."
@@ -105,7 +106,7 @@ class CreateInvestigation(BaseModel):
         None, description="The date the investigation ended."
     )
     investigator_uid: Optional[str] = Field(
-        None, description="The UID of the officer who performed the " "investigation."
+        None, description="The UID of the officer who performed the investigation."
     )
 
 
@@ -162,10 +163,10 @@ class CreateComplaintSource(BaseModel):
         None, description="The agency that reported the record."
     )
     reporting_agency_url: Optional[str] = Field(
-        None, description="The URL of the agency that reported the " "record."
+        None, description="The URL of the agency that reported the record."
     )
     reporting_agency_email: Optional[str] = Field(
-        None, description="The email of the agency that reported the " "record."
+        None, description="The email of the agency that reported the record."
     )
 
 
@@ -204,10 +205,10 @@ class CreateComplaint(BaseModel):
         None, description="The outcome of the contact."
     )
     civilian_witnesses: Optional[List[CreateCivilian]] = Field(
-        None, description="The civilian witnesses associated with the " "complaint."
+        None, description="The civilian witnesses associated with the complaint."
     )
     attachments: Optional[List[Attachemnt]] = Field(
-        None, description="Documents and multimedia associated with " "the complaint."
+        None, description="Documents and multimedia associated with the complaint."
     )
     civilian_review_board_uid: Optional[str] = Field(
         None,
@@ -216,13 +217,13 @@ class CreateComplaint(BaseModel):
     )
     police_witnesses: Optional[List[str]] = Field(
         None,
-        description="The UID of any police witnesses associated with " "the complaint.",
+        description="The UID of any police witnesses associated with the complaint.",
     )
     allegations: Optional[List[CreateAllegation]] = Field(
         None, description="The allegations associated with the complaint."
     )
     investigations: Optional[List[CreateInvestigation]] = Field(
-        None, description="The investigations associated with the " "complaint."
+        None, description="The investigations associated with the complaint."
     )
     penalties: Optional[List[CreatePenalty]] = Field(
         None, description="The penalties associated with the complaint."
@@ -253,10 +254,10 @@ class UpdateComplaint(BaseModel):
         None, description="The outcome of the contact."
     )
     civilian_witnesses: Optional[List[CreateCivilian]] = Field(
-        None, description="The civilian witnesses associated with the " "complaint."
+        None, description="The civilian witnesses associated with the complaint."
     )
     attachments: Optional[List[Attachemnt]] = Field(
-        None, description="Documents and multimedia associated with " "the complaint."
+        None, description="Documents and multimedia associated with the complaint."
     )
     civilian_review_board_uid: Optional[str] = Field(
         None,
@@ -265,13 +266,13 @@ class UpdateComplaint(BaseModel):
     )
     police_witnesses: Optional[List[str]] = Field(
         None,
-        description="The UID of any police witnesses associated with " "the complaint.",
+        description="The UID of any police witnesses associated with the complaint.",
     )
     allegations: Optional[List[CreateAllegation]] = Field(
         None, description="The allegations associated with the complaint."
     )
     investigations: Optional[List[CreateInvestigation]] = Field(
-        None, description="The investigations associated with the " "complaint."
+        None, description="The investigations associated with the complaint."
     )
     penalties: Optional[List[CreatePenalty]] = Field(
         None, description="The penalties associated with the complaint."

--- a/backend/routes/tmp/pydantic/complaints.py
+++ b/backend/routes/tmp/pydantic/complaints.py
@@ -102,10 +102,10 @@ class CreatePenalty(BaseModel):
 
 
 class CreateInvestigation(BaseModel):
-    start_date: Optional[str] = Field(
+    start_date: Optional[date] = Field(
         None, description="The date the investigation started."
     )
-    end_date: Optional[str] = Field(
+    end_date: Optional[date] = Field(
         None, description="The date the investigation ended."
     )
     investigator_uid: Optional[str] = Field(

--- a/backend/routes/tmp/pydantic/complaints.py
+++ b/backend/routes/tmp/pydantic/complaints.py
@@ -7,7 +7,7 @@ from .common import Attachemnt
 from backend.database.models.types.enums import Ethnicity, Gender
 
 
-class Location(BaseModel):
+class CreateLocation(BaseModel):
     """Location object"""
 
     location_type: Optional[str] = Field(
@@ -34,7 +34,7 @@ class Location(BaseModel):
     )
 
 
-class Civilian(BaseModel):
+class CreateCivilian(BaseModel):
     age: Optional[int] = Field(None, description="Estimated age of the individual.")
     age_range: Optional[str] = Field(None, description="Age range of the individual.")
     ethnicity: Optional[Ethnicity] = Field(
@@ -43,41 +43,13 @@ class Civilian(BaseModel):
     gender: Optional[Gender] = Field(None, description="The gender of the individual.")
 
 
-class BaseAllegation(BaseModel):
-    record_id: Optional[str] = Field(
-        None,
-        description="The ID that was given to this allegation by the "
-        "original source of the data.",
-    )
-    complainant: Optional[Civilian] = Field(
-        None,
-        description="Demographic information of the individual "
-        "who filed the complaint.",
-    )
-    allegation: Optional[str] = Field(
-        None, description="The allegation made by the complainant."
-    )
-    type: Optional[str] = Field(None, description="The type of allegation.")
-    sub_type: Optional[str] = Field(None, description="The sub type of the allegation.")
-    recomended_finding: Optional[str] = Field(
-        None, description="The finding recommended by the review board."
-    )
-    recomended_outcome: Optional[str] = Field(
-        None, description="The outcome recommended by the review board."
-    )
-    finding: Optional[str] = Field(None, description="The legal finding.")
-    outcome: Optional[str] = Field(
-        None, description="The final outcome of the allegation."
-    )
-
-
 class CreateAllegation(BaseModel):
     record_id: Optional[str] = Field(
         None,
         description="The ID that was given to this allegation by the "
         "original source of the data.",
     )
-    complainant: Optional[Civilian] = Field(
+    complainant: Optional[CreateCivilian] = Field(
         None,
         description="Demographic information of the individual "
         "who filed the complaint.",
@@ -86,7 +58,7 @@ class CreateAllegation(BaseModel):
         None, description="The allegation made by the complainant."
     )
     type: Optional[str] = Field(None, description="The type of allegation.")
-    sub_type: Optional[str] = Field(None, description="The sub type of the allegation.")
+    subtype: Optional[str] = Field(None, description="The sub type of the allegation.")
     recomended_finding: Optional[str] = Field(
         None, description="The finding recommended by the review board."
     )
@@ -97,7 +69,7 @@ class CreateAllegation(BaseModel):
     outcome: Optional[str] = Field(
         None, description="The final outcome of the allegation."
     )
-    perpetrator_uid: Optional[str] = Field(
+    accused_uid: Optional[str] = Field(
         None, description="The UID of the officer the allegation is " "made against."
     )
 
@@ -125,16 +97,7 @@ class CreatePenalty(BaseModel):
     )
 
 
-class BaseInvestigation(BaseModel):
-    start_date: Optional[str] = Field(
-        None, description="The date the investigation started."
-    )
-    end_date: Optional[str] = Field(
-        None, description="The date the investigation ended."
-    )
-
-
-class CreateInvestigation(BaseInvestigation, BaseModel):
+class CreateInvestigation(BaseModel):
     start_date: Optional[str] = Field(
         None, description="The date the investigation started."
     )
@@ -162,14 +125,14 @@ class ReviewBoard(BaseModel):
     )
 
 
-class SourceDetails(BaseModel):
+class CreateComplaintSource(BaseModel):
     record_type: str = Field(
         None, description="The type of record the complaint is associated with."
     )
-
-
-class LegalAction(BaseModel):
-    record_type: Literal["legal"]
+    # Legal Action Properties
+    date_published: Optional[date] = Field(
+        None, description="The date the record was published."
+    )
     court: Optional[str] = Field(
         None, description="The court the legal action was filed in."
     )
@@ -179,17 +142,22 @@ class LegalAction(BaseModel):
     docket_number: Optional[str] = Field(
         None, description="The docket number of the case."
     )
-    date_of_action: Optional[str] = Field(
+    case_event_date: Optional[date] = Field(
         None, description="The date the legal action was filed."
     )
 
+    # News Report Properties
+    publication_name: Optional[str] = Field(
+        None, description="The name of the publication."
+    )
+    publication_url: Optional[str] = Field(
+        None, description="The URL of the publication."
+    )
+    author: Optional[str] = Field(None, description="The author of the publication.")
+    author_url: Optional[str] = Field(None, description="The URL of the author.")
+    author_email: Optional[str] = Field(None, description="The email of the author.")
 
-class PersonalAccount(BaseModel):
-    record_type: Literal["personal"]
-
-
-class GovernmentRecord(BaseModel):
-    record_type: Literal["government"]
+    # Government Record Properties
     reporting_agency: Optional[str] = Field(
         None, description="The agency that reported the record."
     )
@@ -201,34 +169,17 @@ class GovernmentRecord(BaseModel):
     )
 
 
-class NewsReport(BaseModel):
-    record_type: Literal["news"]
-    publication_name: Optional[str] = Field(
-        None, description="The name of the publication."
-    )
-    publication_date: Optional[str] = Field(
-        None, description="The date the publication was released."
-    )
-    publication_url: Optional[str] = Field(
-        None, description="The URL of the publication."
-    )
-    author: Optional[str] = Field(None, description="The author of the publication.")
-    author_url: Optional[str] = Field(None, description="The URL of the author.")
-    author_email: Optional[str] = Field(None, description="The email of the author.")
-
-
 class CreateComplaint(BaseModel):
+    source_uid: str = Field(
+        None, description="The UID of the source that reported the complaint."
+    )
+    source_details: CreateComplaintSource = Field(
+        None, description="Details about the sourcing of the complaint."
+    )
     record_id: Optional[str] = Field(
         None,
         description="The ID that was given to this complaint by the "
         "original source of the data.",
-    )
-    source_details: Union[
-        LegalAction, PersonalAccount, GovernmentRecord, NewsReport
-    ] = Field(
-        None,
-        description="The source details of the complaint.",
-        discriminator="record_type",
     )
     category: Optional[str] = Field(None, description="The category of the complaint.")
     incident_date: Optional[date] = Field(
@@ -245,14 +196,14 @@ class CreateComplaint(BaseModel):
     updated_date: Optional[date] = Field(
         None, description="The date and time the complaint was last updated."
     )
-    location: Optional[Dict[str, Any]] = None
+    location: Optional[CreateLocation] = None
     reason_for_contact: Optional[str] = Field(
         None, description="The reason for the contact."
     )
     outcome_of_contact: Optional[str] = Field(
         None, description="The outcome of the contact."
     )
-    civilian_witnesses: Optional[List[Civilian]] = Field(
+    civilian_witnesses: Optional[List[CreateCivilian]] = Field(
         None, description="The civilian witnesses associated with the " "complaint."
     )
     attachments: Optional[List[Attachemnt]] = Field(
@@ -301,7 +252,7 @@ class UpdateComplaint(BaseModel):
     outcome_of_contact: Optional[str] = Field(
         None, description="The outcome of the contact."
     )
-    civilian_witnesses: Optional[List[Civilian]] = Field(
+    civilian_witnesses: Optional[List[CreateCivilian]] = Field(
         None, description="The civilian witnesses associated with the " "complaint."
     )
     attachments: Optional[List[Attachemnt]] = Field(

--- a/backend/routes/tmp/pydantic/complaints.py
+++ b/backend/routes/tmp/pydantic/complaints.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
-from .common import Attachemnt
+from .common import Attachment
 from backend.database.models.types.enums import Ethnicity, Gender
 
 
@@ -93,7 +93,7 @@ class CreatePenalty(BaseModel):
         None, description="The agency's disposition."
     )
     penalty: Optional[str] = Field(None, description="A description of the penalty.")
-    date_assesed: Optional[date] = Field(
+    date_assessed: Optional[date] = Field(
         None, description="The date that the penalty was assessed."
     )
 
@@ -207,7 +207,7 @@ class CreateComplaint(BaseModel):
     civilian_witnesses: Optional[List[CreateCivilian]] = Field(
         None, description="The civilian witnesses associated with the complaint."
     )
-    attachments: Optional[List[Attachemnt]] = Field(
+    attachments: Optional[List[Attachment]] = Field(
         None, description="Documents and multimedia associated with the complaint."
     )
     civilian_review_board_uid: Optional[str] = Field(
@@ -256,7 +256,7 @@ class UpdateComplaint(BaseModel):
     civilian_witnesses: Optional[List[CreateCivilian]] = Field(
         None, description="The civilian witnesses associated with the complaint."
     )
-    attachments: Optional[List[Attachemnt]] = Field(
+    attachments: Optional[List[Attachment]] = Field(
         None, description="Documents and multimedia associated with the complaint."
     )
     civilian_review_board_uid: Optional[str] = Field(

--- a/backend/routes/tmp/pydantic/complaints.py
+++ b/backend/routes/tmp/pydantic/complaints.py
@@ -22,14 +22,14 @@ class CreateLocation(BaseModel):
     city: Optional[str] = Field(None, description="The city the location is in.")
     state: Optional[str] = Field(None, description="The state the location is in.")
     zip: Optional[str] = Field(None, description="The zip code of the location.")
-    responsibility: Optional[str] = Field(
+    administrative_area: Optional[str] = Field(
         None,
-        description="The responsibility area this location is assigned "
+        description="The administrative area this location is assigned "
         "by the local law enforcement agency.",
     )
-    responsibility_type: Optional[str] = Field(
+    administrative_area_type: Optional[str] = Field(
         None,
-        description="The type of responsibility area. For example: Beat, "
+        description="The type of administrative area. For example: Beat, "
         "Sector, Precinct, etc.",
     )
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -122,7 +122,7 @@ def example_user():
 
 
 @pytest.fixture
-def example_source(scope="session"):
+def example_source():
     source = Source(
         name="Example Source",
         url="www.example.com",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -96,7 +96,7 @@ def is_test_database():
     return bool(results)
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(autouse=True)
 def cleanup_test_data():
     yield
     # Check if this is the test database before performing any deletion

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -239,6 +239,7 @@ def example_contributor(example_source):
 
 @pytest.fixture  # type: ignore
 def example_complaint(
+    db_session,
     example_source: Source,
     example_contributor: User,
     example_officer: Officer,
@@ -270,9 +271,9 @@ def example_complaint(
         administrative_area_type="Precinct"
     ).save()
     allegation = Allegation(
-        allegation = "Officer used unnecessary force during arrest",
-        type = "Excessive Force",
-        subtype = "Physical Force",
+        allegation="Officer used unnecessary force during arrest",
+        type="Excessive Force",
+        subtype="Physical Force",
         recommended_finding="Sustained",
         finding="Sustained",
         recommended_outcome="Disciplinary Action",
@@ -297,12 +298,13 @@ def example_complaint(
     complaint.investigations.connect(investigation)
     complaint.penalties.connect(penalty)
     complaint.location.connect(location)
-    complaint.source_org.connect(example_source,source_rel)
+    complaint.source_org.connect(example_source, source_rel)
     add_test_property(location)
     add_test_property(complaint)
     add_test_property(allegation)
     add_test_property(penalty)
     add_test_property(investigation)
+    add_test_property_to_rel(complaint, 'HAS_SOURCE', example_source)
 
     yield complaint
 

--- a/backend/tests/test_agencies.py
+++ b/backend/tests/test_agencies.py
@@ -136,7 +136,7 @@ def test_get_all_agencies(client, access_token, example_agencies):
     assert res.json["results"].__len__() == total_agencies
 
 
-def test_filter_agencies(client, access_token):
+def test_filter_agencies(client, access_token, example_agencies):
     # Test filtering
     expect_name_ct = Agency.nodes.filter(
         name="New York Police Department"

--- a/backend/tests/test_complaints.py
+++ b/backend/tests/test_complaints.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+import pytest
+import math
+from datetime import date
+from backend.database import (
+    Complaint, Source, RecordType, Officer
+)
+
+mock_complaint = {
+    "record_id": "202202712",
+    "source_details": {
+        "record_type": "government",
+        "reporting_agency": "New York City Civilian Complaint Review Board",
+        "reporting_agency_url": "https://www.nyc.gov/site/ccrb/index.page",
+        "reporting_agency_email": None
+    },
+    "category": None,
+    "incident_date": "2022-04-15",
+    "received_date": "2022-04-29",
+    "closed_date": "2023-07-20",
+    "location": {
+        "location_type": "Subway station/train",
+        "location_description": "Midtown North Precinct, Manhattan",
+        "address": None,
+        "city": "Manhattan",
+        "state": "NY",
+        "zip": None,
+        "administrative_area": "Midtown North Precinct",
+        "administrative_area_type": "precinct"
+    },
+    "reason_for_contact": "C/V intervened on behalf of/observed encounter w/3rd party",
+    "outcome_of_contact": "Arrest - disorderly conduct",
+    "civilian_witnesses": None,
+    "attachments": [
+        {
+            "filetype": "application/pdf",
+            "url": "https://www.documentcloud.org/documents/25189362-202202712_redactedclosingreportpdf",
+            "title": "Complaint Closing Report"
+        }
+    ],
+    "civilian_review_board_uid": None,
+    "police_witnesses": None,
+    "allegations": [
+        {
+            "record_id": None,
+            "complainant": {
+                "age": 37,
+                "age_range": "35-39",
+                "ethnicity": None,
+                "gender": "Male"
+            },
+            "allegation": "Refusal to process civilian complaint",
+            "type": "Abuse of Authority",
+            "subtype": None,
+            "recommended_finding": None,
+            "recommended_outcome": None,
+            "finding": "Substantiated",
+            "outcome": "Command Discipline B"
+        }
+    ],
+    "investigations": None,
+    "penalties": [
+        {
+            "crb_plea": None,
+            "crb_case_status": None,
+            "crb_disposition": None,
+            "agency_disposition": "Substantiated",
+            "penalty": "Command Discipline B",
+            "date_assessed": "2023-07-20"
+        }
+    ]
+}
+
+
+def test_create_complaint(
+        db_session,
+        client,
+        contributor_access_token,
+        example_source: Source,
+        example_officer: Officer,
+    ):
+    """
+    Test that we can create a complaint.
+    """
+    request = {
+        "record_id": mock_complaint["record_id"],
+        "source_details": mock_complaint["source_details"],
+        "category": mock_complaint["category"],
+        "incident_date": mock_complaint["incident_date"],
+        "received_date": mock_complaint["received_date"],
+        "closed_date": mock_complaint["closed_date"],
+        "location": mock_complaint["location"],
+        "reason_for_contact": mock_complaint["reason_for_contact"],
+        "outcome_of_contact": mock_complaint["outcome_of_contact"],
+        "source_uid": example_source.uid,
+        "attachments": mock_complaint["attachments"],
+        "allegations": mock_complaint["allegations"],
+        "penalties": mock_complaint["penalties"],
+    }
+    request['allegations'][0]['accused_uid'] = example_officer.uid
+    request['penalties'][0]['officer_uid'] = example_officer.uid
+    res = client.post(
+        "/api/v1/complaints/",
+        json=request,
+        headers={
+            "Authorization": "Bearer {0}".format(contributor_access_token)
+        },
+    )
+    assert res.status_code == 200
+    response = res.json
+
+    complaint_obj = (
+       Complaint.nodes.get(uid=response["uid"])
+    )
+    assert complaint_obj.record_id == request["record_id"]
+    assert complaint_obj.category == request["category"]
+    assert complaint_obj.reason_for_contact == request["reason_for_contact"]
+    assert complaint_obj.outcome_of_contact == request["outcome_of_contact"]
+    assert complaint_obj.incident_date == date.fromisoformat(request["incident_date"])
+    assert complaint_obj.received_date == date.fromisoformat(request["received_date"])
+    assert complaint_obj.closed_date == date.fromisoformat(request["closed_date"])
+
+    location = complaint_obj.location.single()
+    source_obj = complaint_obj.source_org.single()
+    source_rel = complaint_obj.source_org.relationship(source_obj)
+    attachment_obj = complaint_obj.attachments.single()
+    allegation_obj = complaint_obj.allegations.single()
+    complainant_obj = allegation_obj.complainant.single()
+    penalty_obj = complaint_obj.penalties.single()
+
+    for prop, value in request["location"].items():
+        assert getattr(location, prop) == value
+    for prop, value in request["source_details"].items():
+        assert getattr(source_rel, prop) == value
+    for prop, value in request["attachments"][0].items():
+        assert getattr(attachment_obj, prop) == value
+    for prop, value in request["allegations"][0].items():
+        if prop == "accused_uid":
+            assert allegation_obj.accused.single().uid == value
+        elif prop == "complainant":
+            for sub_prop, sub_value in value.items():
+                assert getattr(complainant_obj, sub_prop) == sub_value
+        else:
+            assert getattr(allegation_obj, prop) == value
+    for prop, value in request["penalties"][0].items():
+        if prop == "officer_uid":
+            assert penalty_obj.officer.single().uid == value
+        elif prop == "date_assessed":
+            assert penalty_obj.date_assessed == date.fromisoformat(value)
+        else:
+            assert getattr(penalty_obj, prop) == value
+
+
+
+def test_get_complaint(client, db_session, example_complaint, access_token):
+    """Test that we can retrieve a complaint by its UID.
+    """
+    res = client.get(f"/api/v1/complaints/{example_complaint.uid}")
+
+    assert res.status_code == 200
+    assert res.json["record_id"] == example_complaint.record_id
+    assert res.json["category"] == example_complaint.category
+    assert res.json["reason_for_contact"] == example_complaint.reason_for_contact
+    assert res.json["outcome_of_contact"] == example_complaint.outcome_of_contact
+    assert res.json["incident_date"] == example_complaint.incident_date.isoformat()
+    assert res.json["received_date"] == example_complaint.received_date.isoformat()
+    assert res.json["closed_date"] == example_complaint.closed_date.isoformat()
+
+    for prop, value in res.json['location'][0].items():
+        assert getattr(example_complaint.location.single(), prop) == value
+
+    for prop, value in res.json['allegations'][0].items():
+        assert getattr(example_complaint.allegations.single(), prop) == value
+
+    for prop, value in res.json['penalties'][0].items():
+        if prop == "date_assessed":
+            assert getattr(
+                example_complaint.penalties.single(),
+                prop
+            ).isoformat() == value
+        else:
+            assert getattr(
+                example_complaint.penalties.single(), prop) == value
+
+
+def test_get_complaints(client, db_session, access_token, example_complaint):
+    all_complaints = Complaint.nodes.all()
+    res = client.get(
+        "/api/v1/complaints/",
+        headers={"Authorization ": "Bearer {0}".format(access_token)},
+    )
+
+    assert res.status_code == 200
+
+
+def test_complaint_pagination(client, db_session, access_token, example_complaint):
+    # Create Complaints in the database
+    complaints = Complaint.nodes.all()
+    per_page = 1
+    expected_total_pages = math.ceil(len(complaints)//per_page)
+
+    for page in range(1, expected_total_pages + 1):
+        res = client.get(
+            "/api/v1/complaints/",
+            query_string={"per_page": per_page, "page": page},
+            headers={"Authorization": "Bearer {0}".format(access_token)},
+        )
+
+        assert res.status_code == 200
+        assert res.json["page"] == page
+        assert res.json["total"] == len(complaints)
+        assert len(res.json["results"]) == per_page
+
+    res = client.get(
+        "/api/v1/complaints/",
+        query_string={"perPage": per_page, "page": expected_total_pages + 1},
+        headers={"Authorization": "Bearer {0}".format(access_token)},
+    )
+    assert res.status_code == 404
+
+
+# def test_update_complaint(client, db_session, contributor_access_token, example_complaint):
+#     """Test that we can update an existing complaint."""
+#     updated_data = {
+#         "record_id": "202202713",
+#         "reason_for_contact": "Updated reason for contact",
+#         "outcome_of_contact": "Updated outcome of contact",
+#     }
+
+#     res = client.put(
+#         f"/api/v1/complaints/{example_complaint.uid}",
+#         json=updated_data,
+#         headers={"Authorization": f"Bearer {contributor_access_token}"},
+#     )
+
+#     assert res.status_code == 200
+#     response = res.json
+
+#     assert response["record_id"] == updated_data["record_id"]
+#     assert response["reason_for_contact"] == updated_data["reason_for_contact"]
+#     assert response["outcome_of_contact"] == updated_data["outcome_of_contact"]
+
+#     # Verify the database is updated
+#     complaint_obj = Complaint.nodes.get(uid=example_complaint.uid)
+#     assert complaint_obj.record_id == updated_data["record_id"]
+#     assert complaint_obj.reason_for_contact == updated_data["reason_for_contact"]
+#     assert complaint_obj.outcome_of_contact == updated_data["outcome_of_contact"]
+
+
+# def test_delete_complaint(client, db_session, contributor_access_token, example_complaint):
+#     """Test that we can delete an existing complaint."""
+#     res = client.delete(
+#         f"/api/v1/complaints/{example_complaint.uid}",
+#         headers={"Authorization": f"Bearer {contributor_access_token}"},
+#     )
+
+#     assert res.status_code == 204
+
+#     # Verify the complaint is deleted
+#     with pytest.raises(Complaint.DoesNotExist):
+#         Complaint.nodes.get(uid=example_complaint.uid)
+
+# def test_get_allegations(client, db_session, example_complaint, access_token):
+#     """Test that we can retrieve allegations associated with a complaint."""
+#     res = client.get(
+#         f"/api/v1/complaints/{example_complaint.uid}/allegations",
+#         headers={"Authorization": f"Bearer {access_token}"},
+#     )
+
+#     assert res.status_code == 200
+#     allegations = res.json["results"]
+#     assert len(allegations) > 0
+#     assert allegations[0]["allegation"] == example_complaint.allegations[0]["allegation"]
+#     assert allegations[0]["type"] == example_complaint.allegations[0]["type"]
+
+# def test_get_penalties(client, db_session, example_complaint, access_token):
+#     """Test that we can retrieve penalties associated with a complaint."""
+#     res = client.get(
+#         f"/api/v1/complaints/{example_complaint.uid}/penalties",
+#         headers={"Authorization": f"Bearer {access_token}"},
+#     )
+
+#     assert res.status_code == 200
+#     penalties = res.json["results"]
+#     assert len(penalties) > 0
+#     assert penalties[0]["penalty"] == example_complaint.penalties[0]["penalty"]
+#     assert penalties[0]["date_assessed"] == example_complaint.penalties[0]["date_assessed"]
+
+# def test_get_investigations(client, db_session, example_complaint, access_token):
+#     """Test that we can retrieve investigations associated with a complaint."""
+#     res = client.get(
+#         f"/api/v1/complaints/{example_complaint.uid}/investigations",
+#         headers={"Authorization": f"Bearer {access_token}"},
+#     )
+
+#     assert res.status_code == 200
+#     investigations = res.json["results"]
+#     assert len(investigations) > 0
+#     # Assuming the first investigation matches the example complaint's investigation
+#     assert investigations[0]["start_date"] == example_complaint.investigations[0]["start_date"]
+#     assert investigations[0]["end_date"] == example_complaint.investigations[0]["end_date"]
+
+# def test_update_complaint_children(client, db_session, contributor_access_token, example_complaint):
+    # """Test that we can update the children of an existing complaint."""
+    # updated_data = {
+    #     "allegations": [
+    #         {
+    #             "allegation": "Updated allegation",
+    #             "type": "Updated type"
+    #         }
+    #     ],
+    #     "penalties": [
+    #         {
+    #             "penalty": "Updated penalty",
+    #             "date_assessed": "2022-01-01"
+    #         }
+    #     ],
+    #     "investigations": [
+    #         {
+    #             "start_date": "2022-01-01",
+    #             "end_date": "2022-01-02"
+    #         }
+    #     ]
+    # }
+
+    # res = client.put(
+    #     f"/api/v1/complaints/{example_complaint.uid}",
+    #     json=updated_data,
+    #     headers={"Authorization": f"Bearer {contributor_access_token}"},
+    # )
+
+    # assert res.status_code == 200
+    # response = res.json
+
+    # assert response["allegations"] == updated_data["allegations"]
+    # assert response["penalties"] == updated_data["penalties"]
+    # assert response["investigations"] == updated_data["investigations"]
+
+    # # Verify the database is updated
+    # complaint_obj = Complaint.nodes.get(uid=example_complaint.uid)
+    # assert complaint_obj.allegations == updated_data["allegations"]
+    # assert complaint_obj.penalties == updated_data["penalties"]
+    # assert complaint_obj.investigations == updated_data["investigations"]

--- a/oas/2.0/complaints.yaml
+++ b/oas/2.0/complaints.yaml
@@ -18,8 +18,93 @@ security:
   - bearerAuth: []
 tags:
   - name: "Complaints"
-    description: "Complaints API"
+    description: "Manage Complaints"
+  - name: "Allegations"
+    description: "Manage Allegations"
+  - name: "Investigations"
+    description: "Manage Investigations"
+  - name: "Penalties"
+    description: "Manage Penalties"
 paths:
+  /complaints:
+    post:
+      tags: 
+        - "Complaints"
+      summary: "Create Complaint"
+      operationId: "createComplaint"
+      description: >
+        Create a single complaint. User must be a
+        contributor to create an complaint.
+      requestBody:
+        description: "Complaint object that needs to be added to the database"
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateComplaint"
+      responses:
+        '200':
+          description: "A JSON array of user names"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Complaint"
+        '400':
+          $ref: '../common/error.yaml#/components/responses/validationError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '409':
+          $ref: '../common/error.yaml#/components/responses/conflictError'
+    get:
+      tags: 
+        - "Complaints"
+      summary: "Get Complaints"
+      operationId: "getComplaints"
+      description: >
+       Returns all complaints in the database. Filters can be applied
+       to narrow down the results.
+      parameters:
+        - $ref: '../common/pagination.yaml#/components/parameters/page'
+        - $ref: '../common/pagination.yaml#/components/parameters/per_page'
+        - $ref: '#/components/parameters/source_uid'
+        - $ref: '#/components/parameters/source_type'
+        - $ref: '#/components/parameters/officers_involved'
+        - $ref: '#/components/parameters/category'
+        - $ref: '#/components/parameters/reason_for_contact'
+        - $ref: '#/components/parameters/outcome_of_contact'
+        - $ref: '#/components/parameters/date_gte'
+        - $ref: '#/components/parameters/date_lte'
+      responses:
+        '200':
+          description: "A JSON array of complaint objects"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ComplaintList"
+        "401":
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '400':
+          $ref: '../common/error.yaml#/components/responses/validationError'
+  /complaints/latest:
+    get:
+      tags: 
+        - "Complaints"
+      summary: "Latest Complaint Updates"
+      operationId: "getLatestComplaints"
+      description: >
+        Returns the most recently updated or added complaints.
+      parameters:
+        - $ref: '../common/pagination.yaml#/components/parameters/page'
+        - $ref: '../common/pagination.yaml#/components/parameters/per_page'
+      responses:
+        '200':
+          description: "A JSON array of complaint objects"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ComplaintList"
+        "401":
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
   /complaints/{complaint_uid}:
     get:
       parameters:
@@ -35,7 +120,7 @@ paths:
       description: >
         Returns information about a single complaint.
       responses:
-        "200":
+        '200':
           description: "A complaint object"
           content:
             application/json:
@@ -68,7 +153,7 @@ paths:
             schema:
               $ref: "#/components/schemas/UpdateComplaint"
       responses:
-        "200":
+        '200':
           description: "A complaint object"
           content:
             application/json:
@@ -79,86 +164,498 @@ paths:
         '404':
           $ref: '../common/error.yaml#/components/responses/notFoundError'
         '401':
-          $ref: '../common/error.yaml#/components/responses/unauthorizedError'  
-  /complaints:
-    post:
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError' 
+  /complaints/{complaint_uid}/allegations:
+    get:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
       tags: 
-        - "Complaints"
-      summary: "Create Complaint"
-      operationId: "createComplaint"
+        - "Allegations"
+      summary: "Get Allegations for Complaint"
+      operationId: "getComplaintAllegations"
       description: >
-        Create a single complaint. User must be a
-        contributor to create an complaint.
+        Returns all allegations associated with a single complaint.
+      responses:
+        '200':
+          description: "A JSON array of allegation objects"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AllegationList"
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+    post:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags: 
+        - "Allegations"
+      summary: "Create Allegation for Complaint"
+      operationId: "createComplaintAllegation"
+      description: >
+        Create a single allegation associated with a complaint. User must have
+        publisher permission in the organization that created the complaint in
+        order to add an allegation.
       requestBody:
-        description: "Complaint object that needs to be added to the database"
+        description: "Allegation object that needs to be added to the database"
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateComplaint"
+              $ref: "#/components/schemas/CreateAllegation"
       responses:
-        "200":
-          description: "A JSON array of user names"
+        '200':
+          description: "An allegation object"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Complaint"
+                $ref: "#/components/schemas/Allegation"
         '400':
           $ref: '../common/error.yaml#/components/responses/validationError'
         '401':
           $ref: '../common/error.yaml#/components/responses/unauthorizedError'
-        '409':
-          $ref: '../common/error.yaml#/components/responses/conflictError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+  /complaints/{complaint_uid}/allegations/{allegation_uid}:
     get:
-      tags: 
-        - "Complaints"
-      summary: "Get Complaints"
-      operationId: "getComplaints"
-      description: >
-       Returns all complaints in the database. Filters can be applied
-       to narrow down the results.
       parameters:
-        - $ref: '../common/pagination.yaml#/components/parameters/page'
-        - $ref: '../common/pagination.yaml#/components/parameters/per_page'
-        - $ref: '#/components/parameters/source_uid'
-        - $ref: '#/components/parameters/source_type'
-        - $ref: '#/components/parameters/officers_involved'
-        - $ref: '#/components/parameters/category'
-        - $ref: '#/components/parameters/reason_for_contact'
-        - $ref: '#/components/parameters/outcome_of_contact'
-        - $ref: '#/components/parameters/date_gte'
-        - $ref: '#/components/parameters/date_lte'
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: allegation_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags: 
+        - "Allegations"
+      summary: "Get Allegation for Complaint"
+      operationId: "getComplaintAllegation"
+      description: >
+        Returns information about a single allegation associated with a complaint.
       responses:
-        "200":
-          description: "A JSON array of complaint objects"
+        '200':
+          description: "An allegation object"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ComplaintList"
-        "401":
+                $ref: "#/components/schemas/Allegation"
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
           $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
+    patch:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+          type: string
+        - name: allegation_uid
+          in: path
+          required: true
+          schema:
+          type: string
+      tags:
+        - "Allegations"
+      summary: "Update Allegation for Complaint"
+      operationId: "updateComplaintAllegation"
+      description: >
+        Update a single allegation associated with a complaint. The user must
+        have publishing permission in the organization that submitted the
+        complaint to update the allegation.
+      requestBody:
+        description: "Allegation object that needs to be updated in the database"
+        required: true
+        content:
+          application/json:
+          schema:
+            $ref: "#/components/schemas/CreateAllegation"
+      responses:
+        '200':
+          description: "An allegation object"
+          content:
+          application/json:
+            schema:
+            $ref: "#/components/schemas/Allegation"
         '400':
           $ref: '../common/error.yaml#/components/responses/validationError'
-  /complaints/latest:
-    get:
-      tags: 
-        - "Complaints"
-      summary: "Latest Complaint Updates"
-      operationId: "getLatestComplaints"
-      description: >
-        Returns the most recently updated or added complaints.
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
+    delete:
       parameters:
-        - $ref: '../common/pagination.yaml#/components/parameters/page'
-        - $ref: '../common/pagination.yaml#/components/parameters/per_page'
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: allegation_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags:
+        - "Allegations"
+      summary: "Delete Allegation for Complaint"
+      operationId: "deleteComplaintAllegation"
+      description: >
+        Delete a single allegation associated with a complaint. The user must
+        have publishing permission in the organization that submitted the
+        complaint to delete the allegation.
       responses:
-        "200":
-          description: "A JSON array of complaint objects"
+        '204':
+          description: "No Content"
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
+  /complaints/{complaint_uid}/investigations:
+    get:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags: 
+        - "Investigations"
+      summary: "Get Investigations for Complaint"
+      operationId: "getComplaintInvestigations"
+      description: >
+        Returns all investigations associated with a single complaint.
+      responses:
+        '200':
+          description: "A JSON array of investigation objects"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ComplaintList"
-        "401":
+                $ref: "#/components/schemas/InvestigationList"
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
           $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+    post:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags: 
+        - "Investigations"
+      summary: "Get Investigations for Complaint"
+      operationId: "createComplaintInvestigation"
+      description: >
+        Creates a new investigation associated with a single complaint.
+      requestBody:
+        description: "Investigation object that needs to be added to the database"
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateInvestigation"
+      responses:
+        '201':
+          description: "A JSON investigation objects"
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/Investigation"
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
+  /complaints/{complaint_uid}/investigations/{investigation_uid}:
+    get:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: investigation_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags: 
+        - "Investigations"
+      summary: "Get Investigation for Complaint"
+      operationId: "getComplaintInvestigation"
+      description: >
+        Returns information about a single investigation associated with a complaint.
+      responses:
+        '200':
+          description: "An investigation object"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Investigation"
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
+    patch:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: investigation_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags:
+        - "Investigations"
+      summary: "Update Investigation for Complaint"
+      operationId: "updateComplaintInvestigation"
+      description: >
+        Update a single investigation associated with a complaint. The user must
+        have publishing permission in the organization that submitted the
+        complaint to update the investigation.
+      requestBody:
+        description: "Investigation object that needs to be updated in the database"
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateInvestigation"
+      responses:
+        '200':
+          description: "An investigation object"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Investigation"
+        '400':
+          $ref: '../common/error.yaml#/components/responses/validationError'
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
+    delete:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: investigation_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags:
+        - "Investigations"
+      summary: "Delete Investigation for Complaint"
+      operationId: "deleteComplaintInvestigation"
+      description: >
+        Delete a single investigation associated with a complaint. The user must
+        have publishing permission in the organization that submitted the
+        complaint to delete the investigation.
+      responses:
+        '204':
+          description: "No Content"
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
+  /complaints/{complaint_uid}/penalties:
+    get:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags: 
+        - "Penalties"
+      summary: "Get Penalties for Complaint"
+      operationId: "getComplaintPenalties"
+      description: >
+        Returns all penalties associated with a single complaint.
+      responses:
+        '200':
+          description: "A JSON array of penalty objects"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PenaltyList"
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+    post:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags: 
+        - "Penalties"
+      summary: "Create Penalty for Complaint"
+      operationId: "createComplaintPenalty"
+      description: >
+        Create a single penalty associated with a complaint. User must have
+        publisher permission in the organization that created the complaint in
+        order to add a penalty.
+      requestBody:
+        description: "Penalty object that needs to be added to the database"
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePenalty"
+      responses:
+        '201':
+          description: "A JSON penalty object"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Penalty"
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
+  /complaints/{complaint_uid}/penalties/{penalty_uid}:
+    get:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: penalty_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags:
+        - "Penalties"
+      summary: "Get Penalty for Complaint"
+      operationId: "getComplaintPenalty"
+      description: >
+        Returns a single penalty associated with a complaint.
+      responses:
+        '200':
+          description: "A JSON penalty object"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Penalty"
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
+    patch:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: penalty_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags:
+        - "Penalties"
+      summary: "Update Penalty for Complaint"
+      operationId: "updateComplaintPenalty"
+      description: >
+        Update a single penalty associated with a complaint. The user must
+        have publishing permission in the organization that submitted the
+        complaint to update the penalty.
+      requestBody:
+        description: "Penalty object that needs to be updated in the database"
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePenalty"
+      responses:
+        '200':
+          description: "A JSON penalty object"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Penalty"
+        '400':
+          $ref: '../common/error.yaml#/components/responses/validationError'
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
+    delete:
+      parameters:
+        - name: complaint_uid
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: penalty_uid
+          in: path
+          required: true
+          schema:
+            type: string
+      tags:
+        - "Penalties"
+      summary: "Delete Penalty for Complaint"
+      operationId: "deleteComplaintPenalty"
+      description: >
+        Delete a single penalty associated with a complaint. The user must
+        have publishing permission in the organization that submitted the
+        complaint to delete the penalty.
+      responses:
+        '204':
+          description: "No Content"
+        '404':
+          $ref: '../common/error.yaml#/components/responses/notFoundError'
+        '401':
+          $ref: '../common/error.yaml#/components/responses/unauthorizedError'
+        '403':
+          $ref: '../common/error.yaml#/components/responses/forbiddenError'
 components:
   securitySchemes:
     bearerAuth:
@@ -255,27 +752,36 @@ components:
         location:
           type: object
           properties:
-            address1:
+            location_type:
               type: "string"
-              description: "The address of the incident."
-            address2:
+              description: >
+                The type of location where the incident occurred. For example,
+                Bar, Residence, or Highway.
+            location_description:
               type: "string"
-              description: "The address of the incident."
+              description: "A description of the location where the incident occurred."
+            address:
+              type: "string"
+              description: "The street address where the incident occurred."
             city:
               type: "string"
-              description: "The city of the incident."
+              description: "The city where the incident occurred."
             state:
               type: "string"
-              description: "The state of the incident."
+              description: "The state where the incident occurred."
             zip:
               type: "string"
-              description: "The zip code of the incident."
-            latitude:
-              type: "number"
-              description: "The latitude of the incident."
-            longitude:
-              type: "number"
-              description: "The longitude of the incident."
+              description: "The zip code where the incident occurred."
+            administrative_area:
+              type: "string"
+              description: >
+                The name of the administrative area where the incident occurred.
+                For example, 23rd Precinct or Beat 12.
+            administrative_area_type:
+              type: "string"
+              description: >
+                The type of area designation for determining responsibility.
+                For example, Precinct or Beat.
         reason_for_contact:
           type: "string"
           description: "The reason for the contact."
@@ -439,7 +945,7 @@ components:
         type:
           type: string
           description: The type of allegation.
-        sub_type:
+        subtype:
           type: string
           description: The sub type of the allegation.
         recomended_finding:
@@ -470,37 +976,76 @@ components:
             uid:
               type: "string"
               description: "Unique identifier for the allegation."
-            perpetrator:
+            accused:
               allOf: 
                 - $ref: officers.yaml#/components/schemas/Officer
                 - type: "object"
                   description: The officer who the allegation is made against.
-    Penalty:
+    AllegationList:
+      allOf: 
+        - $ref: '../common/pagination.yaml#/components/schemas/PaginatedResponse'
+        - type: "object"
+          properties:
+            results:
+              type: "array"
+              description: "List of allegations."
+              items:
+                $ref: "#/components/schemas/Allegation"
+    BasePenalty:
       type: "object"
       properties:
-        uid:
+        penalty:
           type: string
-          description: UUID for the penalty.
-        officer:
-          allOf: 
-            - $ref: officers.yaml#/components/schemas/Officer
-            - type: "object"
-              description: "The officer who the penalty is associated with."
-        description:
-          type: "string"
-          description: "A description of the penalty."
-        date_assesed:
+          description: "The penalty imposed."
+        crb_plea:
+          type: string
+          description: "The plea entered by the officer in response to the penalty."
+        crb_case_status:
+          type: string
+          description: "The status of the civilian review board case related to the penalty."
+        crb_disposition:
+          type: string
+          description: "The disposition of the civilian review board case related to the penalty."
+        agency_disposition:
+          type: string
+          description: "The disposition of the agency related to the penalty."
+        date_assessed:
           type: string
           format: date
+    Penalty:
+      allOf: 
+        - $ref: "#/components/schemas/BasePenalty"
+        - type: "object"
+          properties:
+            uid:
+              type: "string"
+              description: "Unique identifier for the penalty."
+            officer:
+              allOf: 
+                - $ref: officers.yaml#/components/schemas/Officer
+                - type: "object"
+                  description: "The officer who suffered the penalty."
     CreatePenalty:
-      type: "object"
-      properties:
-        officer_uid:
-          type: "string"
-          description: "The UID of the officer the penalty is associated with."
-        description:
-          type: "string"
-          description: "A description of the penalty."
+      allOf: 
+        - $ref: "#/components/schemas/BasePenalty"
+        - type: "object"
+          properties:
+            officer_uid:
+              type: "string"
+              description: "The UID of the officer the penalty is associated with."
+            description:
+              type: "string"
+              description: "A description of the penalty."
+    PenaltyList:
+      allOf: 
+        - $ref: '../common/pagination.yaml#/components/schemas/PaginatedResponse'
+        - type: "object"
+          properties:
+            results:
+              type: "array"
+              description: "List of penalties."
+              items:
+                $ref: "#/components/schemas/Penalty"
     BaseInvestigation:
       type: object
       properties:
@@ -519,7 +1064,7 @@ components:
           properties:
             investigator_uid:
               type: "string"
-              description: "The UID of the officer who preformed the investigation."
+              description: "The UID of the officer who performed the investigation."
     Investigation:
       allOf: 
         - $ref: "#/components/schemas/BaseInvestigation"
@@ -532,13 +1077,26 @@ components:
               allOf: 
                 - $ref: officers.yaml#/components/schemas/Officer
                 - type: "object"
-                  description: "The officer who preformed the investigation."
+                  description: "The officer who performed the investigation."
+    InvestigationList:
+      allOf: 
+        - $ref: '../common/pagination.yaml#/components/schemas/PaginatedResponse'
+        - type: "object"
+          properties:
+            results:
+              type: "array"
+              description: "List of investigations."
+              items:
+                $ref: "#/components/schemas/Investigation"
     Civilian:
       type: "object"
       properties:
         age:
           type: "string"
           description: "Age range of the individual."
+        age_range:
+          type: "string"
+          description: "The age range of the individual."
         ethnicity:
           type: "string"
           description: "The ethnicity of the individual."

--- a/oas/2.0/complaints.yaml
+++ b/oas/2.0/complaints.yaml
@@ -711,7 +711,7 @@ components:
     date_gte:
       name: date_gte
       in: query
-      description: "Only return complaints that occurred or were recieved after the selected date. This should be a date in the format YYYY-MM-DD."
+      description: "Only return complaints that occurred or were received after the selected date. This should be a date in the format YYYY-MM-DD."
       required: false
       schema:
         type: string
@@ -719,7 +719,7 @@ components:
     date_lte:
       name: date_lte
       in: query
-      description: "Only return complaints that occurred or were recieved before the selected date. This should be a date in the format YYYY-MM-DD."
+      description: "Only return complaints that occurred or were received before the selected date. This should be a date in the format YYYY-MM-DD."
       required: false
       schema:
         type: string
@@ -741,7 +741,7 @@ components:
           type: "string"
           format: "date-time"
           description: "The date and time the incident occurred."
-        recieved_date:
+        received_date:
           type: "string"
           format: "date-time"
           description: "The date and time the complaint was received by the reporting source."
@@ -869,7 +869,7 @@ components:
             - source_uid
             - category
             - incident_date
-            - recieved_date
+            - received_date
             - location
             - allegations
             - penalties
@@ -948,12 +948,12 @@ components:
         subtype:
           type: string
           description: The sub type of the allegation.
-        recomended_finding:
+        recommended_finding:
           type: "string"
-          description: "The finding recomended by the review board."
-        recomended_outcome:
+          description: "The finding recommended by the review board."
+        recommended_outcome:
           type: "string"
-          description: "The outcome recomended by the review board."
+          description: "The outcome recommended by the review board."
         finding:
           type: "string"
           description: "The legal finding."
@@ -1135,15 +1135,15 @@ components:
     Attachments:
       type: "object"
       properties:
-        type:
+        filetype:
           type: "string"
           description: "The type of attachment."
         url:
           type: "string"
-          description: "The url of the attachment."
-        description:
+          description: "The url where the attachment can be accessed."
+        title:
           type: "string"
-          description: "A description of the attachment."
+          description: "The name of the attachment."
     SourceDetails:
       oneOf: 
         - $ref: '#/components/schemas/LegalCaseEvent'

--- a/oas/2.0/complaints.yaml
+++ b/oas/2.0/complaints.yaml
@@ -797,7 +797,7 @@ components:
           type: "array"
           description: "Documents and multimeida associated with the complaint."
           items:
-            $ref: "#/components/schemas/Attachemnts"
+            $ref: "#/components/schemas/Attachments"
     CreateComplaint:
       allOf: 
         - $ref: "#/components/schemas/BaseComplaint"
@@ -1132,7 +1132,7 @@ components:
         url:
           type: string
           description: The website URL for the review board.
-    Attachemnts:
+    Attachments:
       type: "object"
       properties:
         type:

--- a/oas/common/error.yaml
+++ b/oas/common/error.yaml
@@ -33,3 +33,9 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
+    forbiddenError:
+      description: "Forbidden"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"

--- a/oas/pydantic/complaints.py
+++ b/oas/pydantic/complaints.py
@@ -8,7 +8,7 @@ class BaseComplaint(BaseModel):
     source_details: Optional[SourceDetails] = None
     category: Optional[str] = Field(None, description="The category of the complaint.")
     incident_date: Optional[str] = Field(None, description="The date and time the incident occurred.")
-    recieved_date: Optional[str] = Field(None, description="The date and time the complaint was received by the reporting source.")
+    received_date: Optional[str] = Field(None, description="The date and time the complaint was received by the reporting source.")
     closed_date: Optional[str] = Field(None, description="The date and time the complaint was closed.")
     location: Optional[Dict[str, Any]] = None
     reason_for_contact: Optional[str] = Field(None, description="The reason for the contact.")
@@ -22,7 +22,7 @@ class CreateComplaint(BaseComplaint, BaseModel):
     source_details: Optional[SourceDetails] = None
     category: Optional[str] = Field(None, description="The category of the complaint.")
     incident_date: Optional[str] = Field(None, description="The date and time the incident occurred.")
-    recieved_date: Optional[str] = Field(None, description="The date and time the complaint was received by the reporting source.")
+    received_date: Optional[str] = Field(None, description="The date and time the complaint was received by the reporting source.")
     closed_date: Optional[str] = Field(None, description="The date and time the complaint was closed.")
     location: Optional[Dict[str, Any]] = None
     reason_for_contact: Optional[str] = Field(None, description="The reason for the contact.")
@@ -42,7 +42,7 @@ class UpdateComplaint(BaseComplaint, BaseModel):
     source_details: Optional[SourceDetails] = None
     category: Optional[str] = Field(None, description="The category of the complaint.")
     incident_date: Optional[str] = Field(None, description="The date and time the incident occurred.")
-    recieved_date: Optional[str] = Field(None, description="The date and time the complaint was received by the reporting source.")
+    received_date: Optional[str] = Field(None, description="The date and time the complaint was received by the reporting source.")
     closed_date: Optional[str] = Field(None, description="The date and time the complaint was closed.")
     location: Optional[Dict[str, Any]] = None
     reason_for_contact: Optional[str] = Field(None, description="The reason for the contact.")
@@ -61,7 +61,7 @@ class Complaint(BaseComplaint, BaseModel):
     source_details: Optional[SourceDetails] = None
     category: str = Field(..., description="The category of the complaint.")
     incident_date: str = Field(..., description="The date and time the incident occurred.")
-    recieved_date: str = Field(..., description="The date and time the complaint was received by the reporting source.")
+    received_date: str = Field(..., description="The date and time the complaint was received by the reporting source.")
     closed_date: Optional[str] = Field(None, description="The date and time the complaint was closed.")
     location: Dict[str, Any] = ...
     reason_for_contact: Optional[str] = Field(None, description="The reason for the contact.")
@@ -89,8 +89,8 @@ class BaseAllegation(BaseModel):
     allegation: Optional[str] = Field(None, description="The allegation made by the complaintant.")
     type: Optional[str] = Field(None, description="The type of allegation.")
     sub_type: Optional[str] = Field(None, description="The sub type of the allegation.")
-    recomended_finding: Optional[str] = Field(None, description="The finding recomended by the review board.")
-    recomended_outcome: Optional[str] = Field(None, description="The outcome recomended by the review board.")
+    recommended_finding: Optional[str] = Field(None, description="The finding recommended by the review board.")
+    recommended_outcome: Optional[str] = Field(None, description="The outcome recommended by the review board.")
     finding: Optional[str] = Field(None, description="The legal finding.")
     outcome: Optional[str] = Field(None, description="The final outcome of the allegation.")
 
@@ -101,8 +101,8 @@ class CreateAllegation(BaseAllegation, BaseModel):
     allegation: Optional[str] = Field(None, description="The allegation made by the complaintant.")
     type: Optional[str] = Field(None, description="The type of allegation.")
     sub_type: Optional[str] = Field(None, description="The sub type of the allegation.")
-    recomended_finding: Optional[str] = Field(None, description="The finding recomended by the review board.")
-    recomended_outcome: Optional[str] = Field(None, description="The outcome recomended by the review board.")
+    recommended_finding: Optional[str] = Field(None, description="The finding recommended by the review board.")
+    recommended_outcome: Optional[str] = Field(None, description="The outcome recommended by the review board.")
     finding: Optional[str] = Field(None, description="The legal finding.")
     outcome: Optional[str] = Field(None, description="The final outcome of the allegation.")
     perpetrator_uid: Optional[str] = Field(None, description="The UID of the officer the allegation is made against.")
@@ -114,8 +114,8 @@ class Allegation(BaseAllegation, BaseModel):
     allegation: Optional[str] = Field(None, description="The allegation made by the complaintant.")
     type: Optional[str] = Field(None, description="The type of allegation.")
     sub_type: Optional[str] = Field(None, description="The sub type of the allegation.")
-    recomended_finding: Optional[str] = Field(None, description="The finding recomended by the review board.")
-    recomended_outcome: Optional[str] = Field(None, description="The outcome recomended by the review board.")
+    recommended_finding: Optional[str] = Field(None, description="The finding recommended by the review board.")
+    recommended_outcome: Optional[str] = Field(None, description="The outcome recommended by the review board.")
     finding: Optional[str] = Field(None, description="The legal finding.")
     outcome: Optional[str] = Field(None, description="The final outcome of the allegation.")
     uid: Optional[str] = Field(None, description="Unique identifier for the allegation.")

--- a/oas/pydantic/complaints.py
+++ b/oas/pydantic/complaints.py
@@ -14,7 +14,7 @@ class BaseComplaint(BaseModel):
     reason_for_contact: Optional[str] = Field(None, description="The reason for the contact.")
     outcome_of_contact: Optional[str] = Field(None, description="The outcome of the contact.")
     civilian_witnesses: Optional[List[Civilian]] = Field(None, description="The civilian witnesses associated with the complaint.")
-    attachements: Optional[List[Attachemnts]] = Field(None, description="Documents and multimeida associated with the complaint.")
+    attachements: Optional[List[Attachments]] = Field(None, description="Documents and multimeida associated with the complaint.")
 
 
 class CreateComplaint(BaseComplaint, BaseModel):
@@ -28,7 +28,7 @@ class CreateComplaint(BaseComplaint, BaseModel):
     reason_for_contact: Optional[str] = Field(None, description="The reason for the contact.")
     outcome_of_contact: Optional[str] = Field(None, description="The outcome of the contact.")
     civilian_witnesses: Optional[List[Civilian]] = Field(None, description="The civilian witnesses associated with the complaint.")
-    attachements: Optional[List[Attachemnts]] = Field(None, description="Documents and multimeida associated with the complaint.")
+    attachements: Optional[List[Attachments]] = Field(None, description="Documents and multimeida associated with the complaint.")
     source_uid: Optional[str] = Field(None, description="The UID of the source that reported the complaint.")
     civilian_review_board_uid: Optional[str] = Field(None, description="The UID of the civilian review board that reviewed the complaint.")
     police_witnesses: Optional[List[str]] = Field(None, description="The UID of any police witnesses associated with the complaint.")
@@ -48,7 +48,7 @@ class UpdateComplaint(BaseComplaint, BaseModel):
     reason_for_contact: Optional[str] = Field(None, description="The reason for the contact.")
     outcome_of_contact: Optional[str] = Field(None, description="The outcome of the contact.")
     civilian_witnesses: Optional[List[Civilian]] = Field(None, description="The civilian witnesses associated with the complaint.")
-    attachements: Optional[List[Attachemnts]] = Field(None, description="Documents and multimeida associated with the complaint.")
+    attachements: Optional[List[Attachments]] = Field(None, description="Documents and multimeida associated with the complaint.")
     civilian_review_board_uid: Optional[str] = Field(None, description="The UID of the civilian review board that reviewed the complaint.")
     police_witnesses: Optional[List[str]] = Field(None, description="The uid of any police witnesses associated with the complaint.")
     allegations: Optional[List[CreateAllegation]] = Field(None, description="The allegations associated with the complaint.")
@@ -67,7 +67,7 @@ class Complaint(BaseComplaint, BaseModel):
     reason_for_contact: Optional[str] = Field(None, description="The reason for the contact.")
     outcome_of_contact: Optional[str] = Field(None, description="The outcome of the contact.")
     civilian_witnesses: List[Civilian] = Field(..., description="The civilian witnesses associated with the complaint.")
-    attachements: Optional[List[Attachemnts]] = Field(None, description="Documents and multimeida associated with the complaint.")
+    attachements: Optional[List[Attachments]] = Field(None, description="Documents and multimeida associated with the complaint.")
     uid: str = Field(..., description="Unique identifier for the complaint.")
     created_at: str = Field(..., description="Date and time the complaint was created.")
     updated_at: str = Field(..., description="Date and time the complaint was last updated.")
@@ -126,7 +126,7 @@ class Penalty(BaseModel):
     uid: Optional[str] = Field(None, description="UUID for the penalty.")
     officer: Optional[Officer] = Field(None, description="The officer who the penalty is associated with.")
     description: Optional[str] = Field(None, description="A description of the penalty.")
-    date_assesed: Optional[str] = None
+    date_assessed: Optional[str] = None
 
 
 class CreatePenalty(BaseModel):
@@ -166,7 +166,7 @@ class ReviewBoard(BaseModel):
     url: Optional[str] = Field(None, description="The website URL for the review board.")
 
 
-class Attachemnts(BaseModel):
+class Attachments(BaseModel):
     type: Optional[str] = Field(None, description="The type of attachment.")
     url: Optional[str] = Field(None, description="The url of the attachment.")
     description: Optional[str] = Field(None, description="A description of the attachment.")


### PR DESCRIPTION
Adds API endpoints for managing complaint data.
/complaints

The child objects of the complaints API been given their own API
endpoints to allow for more granular access to the data.
Added:
 - /complaints/{complaint_uid}/allegations
 - /complaints/{complaint_uid}/investigations
 - /complaints/{complaint_uid}/penalties

Location `responsibility` and `responsibility_type` have been renamed
`administrative_area` and `administrative_area_type` respectively to
better reflect the data they contain.
Complaint->Location Cardinality has been changed to One.

OAS Specifications have been updated to reflect these changes.
I also updated the specification and models to match existing data
available from the known sources of complaint data.