### PR TITLE
Make sure relationships are only defined once

### DIFF
--- a/backend/database/models/agency.py
+++ b/backend/database/models/agency.py
@@ -134,6 +134,7 @@ class Agency(StructuredNode, JsonSerializable):
     ]
     __hidden_properties__ = ["citations", "state_node",
                              "county_node", "city_node"]
+    __virtual_relationships__ = ["units"]
 
     uid = UniqueIdProperty()
     name = StringProperty()

--- a/backend/database/models/civilian.py
+++ b/backend/database/models/civilian.py
@@ -2,8 +2,7 @@
 from neomodel import (
     StructuredNode,
     StringProperty,
-    IntegerProperty,
-    RelationshipTo
+    IntegerProperty
 )
 from backend.schemas import JsonSerializable
 from backend.database.models.types.enums import Ethnicity, Gender

--- a/backend/database/models/civilian.py
+++ b/backend/database/models/civilian.py
@@ -14,9 +14,3 @@ class Civilian(StructuredNode, JsonSerializable):
     age_range = StringProperty()
     ethnicity = StringProperty(choices=Ethnicity.choices())
     gender = StringProperty(choices=Gender.choices())
-
-    # Relationships
-    complaints = RelationshipTo(
-        "backend.database.models.complaint.Complaint", "COMPLAINED_OF")
-    witnessed_complaints = RelationshipTo(
-        "backend.database.models.complaint.Complaint", "WITNESSED")

--- a/backend/database/models/complaint.py
+++ b/backend/database/models/complaint.py
@@ -69,6 +69,7 @@ class Complaint(StructuredNode, JsonSerializable):
     ]
 
     __hidden_properties__ = ["citations"]
+    __virtual_relationships__ = ["allegations", "investigations", "penalties"]
 
     uid = UniqueIdProperty()
     record_id = StringProperty()
@@ -124,6 +125,13 @@ class Complaint(StructuredNode, JsonSerializable):
 
 
 class Allegation(StructuredNode, JsonSerializable):
+    __property_order__ = [
+        "uid", "record_id", "allegation",
+        "type", "subtype", "recommended_finding",
+        "recommended_outcome", "finding", "outcome"
+    ]
+    __hidden_properties__ = ["complaint"]
+
     uid = UniqueIdProperty()
     record_id = StringProperty()
     allegation = StringProperty()
@@ -151,6 +159,9 @@ class Allegation(StructuredNode, JsonSerializable):
 
 
 class Investigation(StructuredNode, JsonSerializable):
+    __hidden_properties__ = ["complaint"]
+    __property_order__ = ["uid", "start_date", "end_date"]
+
     uid = UniqueIdProperty()
     start_date = DateProperty()
     end_date = DateProperty()
@@ -167,6 +178,13 @@ class Investigation(StructuredNode, JsonSerializable):
 
 
 class Penalty(StructuredNode, JsonSerializable):
+    __property_order__ = [
+        "uid", "penalty", "date_assessed",
+        "crb_plea", "crb_case_status",
+        "crb_disposition", "agency_disposition"
+    ]
+    __hidden_properties__ = ["complaint"]
+
     uid = UniqueIdProperty()
     penalty = StringProperty()
     date_assessed = DateProperty()

--- a/backend/database/models/complaint.py
+++ b/backend/database/models/complaint.py
@@ -1,5 +1,5 @@
 """Define the Classes for Complaints."""
-from backend.schemas import JsonSerializable, PropertyEnum
+from backend.schemas import JsonSerializable, PropertyEnum, RelQuery
 from backend.database.models.source import Citation
 from neomodel import (
     StructuredNode,
@@ -7,12 +7,10 @@ from neomodel import (
     StringProperty,
     Relationship,
     RelationshipTo,
-    RelationshipFrom,
     DateProperty,
     UniqueIdProperty,
     One,
-    ZeroOrOne,
-    db
+    ZeroOrOne
 )
 
 
@@ -96,31 +94,29 @@ class Complaint(StructuredNode, JsonSerializable):
         'backend.database.models.source.Source', "UPDATED_BY", model=Citation)
 
     @property
-    def allegations(self):
+    def allegations(self) -> RelQuery:
         """Get the allegations related to this complaint."""
-        cy = """
-        MATCH (c:Complaint)-[:ALLEGED]->(a:Allegation)
-        WHERE c.uid = $uid
-        RETURN a"""
-        return db.cypher_query(cy, {'uid': self.uid}, resolve_objects=True)
-    
+        base = """
+        MATCH (c:Complaint {uid: $uid})-[:ALLEGED]-(a:Allegation)
+        """
+        return RelQuery(self, base, return_alias="a", inflate_cls=Allegation)
+
     @property
-    def investigations(self):
+    def investigations(self) -> RelQuery:
         """Get the investigations related to this complaint."""
-        cy = """
-        MATCH (c:Complaint)-[:EXAMINED_BY]->(i:Investigation)
-        WHERE c.uid = $uid
-        RETURN i"""
-        return db.cypher_query(cy, {'uid': self.uid}, resolve_objects=True)
-    
+        base = """
+        MATCH (c:Complaint {uid: $uid})-[:EXAMINED_BY]-(i:Investigation)
+        """
+        return RelQuery(
+            self, base, return_alias="i", inflate_cls=Investigation)
+
     @property
-    def penalties(self):
+    def penalties(self) -> RelQuery:
         """Get the penalties related to this complaint."""
-        cy = """
-        MATCH (c:Complaint)-[:RESULTS_IN]->(p:Penalty)
-        WHERE c.uid = $uid
-        RETURN p"""
-        return db.cypher_query(cy, {'uid': self.uid}, resolve_objects=True)
+        base = """
+        MATCH (c:Complaint {uid: $uid})-[:RESULTS_IN]-(p:Penalty)
+        """
+        return RelQuery(self, base, return_alias="p", inflate_cls=Penalty)
 
     def __repr__(self):
         """Represent instance as a unique string."""

--- a/backend/database/models/litigation.py
+++ b/backend/database/models/litigation.py
@@ -26,6 +26,7 @@ class Litigation(StructuredNode, JsonSerializable):
         "settlement_amount", "url", "case_type"
     ]
     __hidden_properties__ = ["citations"]
+    __virtual_relationships__ = ["documents", "dispositions"]
 
     uid = UniqueIdProperty()
     case_title = StringProperty()

--- a/backend/database/models/officer.py
+++ b/backend/database/models/officer.py
@@ -33,6 +33,7 @@ class Officer(StructuredNode, JsonSerializable):
         "gender", "date_of_birth"
     ]
     __hidden_properties__ = ["citations"]
+    __virtual_relationships__ = ["state_ids"]
 
     uid = UniqueIdProperty()
     first_name = StringProperty()

--- a/backend/database/models/source.py
+++ b/backend/database/models/source.py
@@ -126,6 +126,7 @@ class Source(StructuredNode, JsonSerializable):
         "uid", "name", "url",
         "contact_email"
     ]
+    __hidden_properties__ = ["invitations", "staged_invitations"]
     uid = UniqueIdProperty()
 
     name = StringProperty(unique_index=True)

--- a/backend/database/models/user.py
+++ b/backend/database/models/user.py
@@ -8,7 +8,6 @@ from neomodel import (
     StringProperty, DateProperty, BooleanProperty,
     UniqueIdProperty, EmailProperty
 )
-from backend.database.models.source import SourceMember
 
 
 class UserRole(str, PropertyEnum):
@@ -56,9 +55,6 @@ class User(StructuredNode, JsonSerializable):
     phone_number = StringProperty()
 
     # Data Source Relationships
-    sources = Relationship(
-        'backend.database.models.source.Source',
-        "MEMBER_OF_SOURCE", model=SourceMember)
     received_invitations = Relationship(
         'backend.database.models.source.Invitation',
         "RECEIVED")

--- a/backend/database/models/user.py
+++ b/backend/database/models/user.py
@@ -29,7 +29,10 @@ class UserRole(str, PropertyEnum):
 
 # Define the User data-model.
 class User(StructuredNode, JsonSerializable):
-    __hidden_properties__ = ["password_hash"]
+    __hidden_properties__ = [
+        "password_hash", "received_invitations",
+        "extended_invitations", "entended_staged_invitations"
+    ]
     __property_order__ = [
         "uid", "first_name", "last_name",
         "email", "email_confirmed_at",

--- a/backend/routes/complaints.py
+++ b/backend/routes/complaints.py
@@ -46,7 +46,6 @@ def create_allegation(
         allegation = Allegation(**a_data).save()
         allegation.accused.connect(officer)
         allegation.complaint.connect(complaint)
-        complaint.allegations.connect(allegation)
         logging.info(
             f"Allegation {allegation.uid} created "
             f"for Complaint {complaint.uid}")
@@ -131,7 +130,7 @@ def create_penalty(
         raise ValueError("Officer UID is required for the penalty")
     try:
         penalty = Penalty(**p_data).save()
-        complaint.penalties.connect(penalty)
+        penalty.complaint.connect(complaint)
         penalty.officer.connect(officer)
         logging.info(
             f"Penalty {penalty.uid} created for Complaint {complaint.uid}")
@@ -183,7 +182,7 @@ def create_investigation(
     investigator_uid = i_data.pop("investigator_uid", None)
     try:
         investigation = Investigation(**i_data).save()
-        complaint.investigations.connect(investigation)
+        investigation.complaint.connect(complaint)
         logging.info(
             f"Investigation {investigation.uid} created "
             f"for Complaint {complaint.uid}")

--- a/backend/routes/officers.py
+++ b/backend/routes/officers.py
@@ -208,7 +208,7 @@ def get_all_officers():
 
     if unit or active_after or active_before or badge_number or agency:
         cypher_query += """
-            MATCH (o)-[m:MEMBER_OF_UNIT]->(u:Unit)
+            MATCH (o)-[m:MEMBER_OF_UNIT]-(u:Unit)
         """
 
     if agency:

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -7,7 +7,7 @@ import textwrap
 from functools import wraps
 from enum import Enum
 from collections import OrderedDict
-from typing import Any, Optional, TypeVar, Type, List
+from typing import Any, Optional, TypeVar, Type, List, Dict, Tuple
 from flask import abort, request, jsonify, current_app
 from pydantic import BaseModel, ValidationError
 from spectree import SecurityScheme, SpecTree
@@ -237,6 +237,92 @@ def add_pagination_wrapper(
         "total": total,
         "pages": expected_total_pages
     }
+
+
+# A tiny, read-only, chainable relation view.
+class RelQuery:
+    """
+    A tiny, read-only, chainable relation view.
+    Usage:
+        agency.units.filter(
+           "u.name CONTAINS $q", q="SWAT").order_by("u.name").limit(5).all()
+        agency.units.first()
+        agency.units.exists()
+        agency.units.one()  # raises if != 1
+    """
+    def __init__(
+            self, owner: StructuredNode, base_cypher: str,
+            return_alias: str, inflate_cls):
+        self._owner = owner
+        self._base = base_cypher.strip().rstrip(";")
+        self._ret = return_alias
+        self._inflate = inflate_cls
+        self._where: List[str] = []
+        self._params: Dict[str, Any] = {"uid": owner.uid}
+        self._order: Optional[str] = None
+        self._limit: Optional[int] = None
+
+    # ---- builders ----
+    def filter(self, clause: str, /, **params):
+        if clause:
+            self._where.append(f"({clause})")
+        if params:
+            self._params.update(params)
+        return self
+
+    def params(self, **params):
+        self._params.update(params)
+        return self
+
+    def order_by(self, clause: str):
+        self._order = clause
+        return self
+
+    def limit(self, n: int):
+        self._limit = n
+        return self
+
+    # ---- executors ----
+    def _compose(self, count_only: bool = False) -> Tuple[str, Dict[str, Any]]:
+        parts = [self._base]
+        if self._where:
+            parts.append("WHERE " + " AND ".join(self._where))
+        if count_only:
+            parts.append(f"RETURN count({self._ret}) AS c")
+        else:
+            parts.append(f"RETURN {self._ret} AS node")
+            if self._order:
+                parts.append(f"ORDER BY {self._order}")
+            if self._limit is not None:
+                parts.append(f"LIMIT {self._limit}")
+        return " ".join(parts) + ";", self._params
+
+    def all(self):
+        cy, params = self._compose()
+        rows, _ = db.cypher_query(cy, params, resolve_objects=True)
+        # if resolve_objects=True is wired, rows come back as objects already
+        if rows and not isinstance(rows[0][0], StructuredNode):
+            # fallback inflate (in case resolve_objects isn't used)
+            return [self._inflate.inflate(row[0]) for row in rows]
+        return [row[0] for row in rows]
+
+    def first(self):
+        if self._limit is None:
+            self.limit(1)
+        res = self.all()
+        return res[0] if res else None
+
+    def one(self):
+        # exactly one or raise
+        res = self.limit(2).all()
+        if len(res) != 1:
+            raise ValueError(f"Expected exactly one result, got {len(res)}")
+        return res[0]
+
+    def exists(self) -> bool:
+        cy, params = self._compose(count_only=True)
+        rows, _ = db.cypher_query(cy, params)
+        return bool(rows and rows[0][0] > 0)
 
 
 # Update Enums to work well with NeoModel

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -338,6 +338,7 @@ class JsonSerializable:
     """Mix me into a database model to make it JSON serializable."""
     __hidden_properties__ = []
     __property_order__ = []
+    __virtual_relationships__ = []
 
     def to_dict(self, include_relationships=True,
                 relationship_limit: int = 20, exclude_fields=None):
@@ -409,6 +410,17 @@ class JsonSerializable:
                             node.to_dict(include_relationships=False)
                             for node in related_nodes
                         ]
+        # Add virtual relationships
+        for rel_name in self.__virtual_relationships__:
+            if rel_name in all_excludes:
+                continue
+            rel_query = getattr(self, rel_name, None)
+            if isinstance(rel_query, RelQuery):
+                related_nodes = rel_query.limit(relationship_limit).all()
+                obj_props[rel_name] = [
+                    node.to_dict(include_relationships=False)
+                    for node in related_nodes
+                ]
 
         return obj_props
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -175,7 +175,6 @@ def example_unit(example_agency, example_officer, example_source):
     ).save()
 
     # Create relationships
-    agency.units.connect(unit)
     unit.agency.connect(agency)
     unit.citations.connect(source, {
         'date': datetime.now(),
@@ -195,13 +194,11 @@ def example_officer(example_source):
         first_name="John",
         last_name="Doe",
     ).save()
-    officer.state_ids.connect(
-        StateID(
-            id_name="Tax ID Number",
-            state="NY",
-            value="958938"
-        )
-    )
+    StateID(
+        id_name="Tax ID Number",
+        state="NY",
+        value="958938"
+    ).save().officer.connect(officer)
     officer.citations.connect(
         example_source,
         {
@@ -324,18 +321,12 @@ def example_complaint(
     ).save()
 
     allegation.accused.connect(example_officer)
+    allegation.complaint.connect(complaint)
     penalty.officer.connect(example_officer)
-    complaint.allegations.connect(allegation)
-    complaint.investigations.connect(investigation)
-    complaint.penalties.connect(penalty)
+    penalty.complaint.connect(complaint)
+    investigation.complaint.connect(complaint)
     complaint.location.connect(location)
     complaint.source_org.connect(example_source, source_rel)
-    add_test_property(location)
-    add_test_property(complaint)
-    add_test_property(allegation)
-    add_test_property(penalty)
-    add_test_property(investigation)
-    add_test_property_to_rel(complaint, 'HAS_SOURCE', example_source)
 
     yield complaint
 

--- a/backend/tests/test_complaints.py
+++ b/backend/tests/test_complaints.py
@@ -110,7 +110,7 @@ def example_complaints(db_session, example_source, example_officer):
         civ = Civilian(**mock_complaint["allegations"][0]["complainant"]).save()
         allege.complainant.connect(civ)
         allege.accused.connect(example_officer)
-        c.allegations.connect(allege)
+        allege.complaint.connect(c)
         c.location.connect(loc)
         complaints.append(c)
     return complaints
@@ -168,9 +168,9 @@ def test_create_complaint(
     source_obj = c.source_org.single()
     source_rel = c.source_org.relationship(source_obj)
     attachment_obj = c.attachments.single()
-    allegation_obj = c.allegations.single()
+    allegation_obj = c.allegations.first()
     complainant_obj = allegation_obj.complainant.single()
-    penalty_obj = c.penalties.single()
+    penalty_obj = c.penalties.first()
 
     for prop, value in request["location"].items():
         assert getattr(location, prop) == value
@@ -413,7 +413,7 @@ def test_create_allegation(
     # Verify the database is updated
     complaint_obj = Complaint.nodes.get(uid=example_complaint.uid)
     a_obj = Allegation.nodes.get(uid=response["uid"])
-    assert complaint_obj.allegations.is_connected(a_obj)
+    assert a_obj.complaint.is_connected(complaint_obj)
     assert a_obj.allegation == new_allegation["allegation"]
     assert a_obj.type == new_allegation["type"]
     assert a_obj.accused.single().uid == new_allegation["accused_uid"]
@@ -428,7 +428,7 @@ def test_update_allegation(
         "type": "Updated type"
     }
 
-    a = example_complaint.allegations.single()
+    a = example_complaint.allegations.first()
 
     res = client.patch(
         f"/api/v1/complaints/{example_complaint.uid}/allegations/{a.uid}",
@@ -444,7 +444,7 @@ def test_update_allegation(
 
     # Verify the database is updated
     complaint_obj = Complaint.nodes.get(uid=example_complaint.uid)
-    a_obj = complaint_obj.allegations.single()
+    a_obj = complaint_obj.allegations.first()
     assert a_obj.allegation == updated_data["allegation"]
     assert a_obj.type == updated_data["type"]
 
@@ -453,14 +453,14 @@ def test_update_allegation(
         headers={"Authorization": f"Bearer {contributor_access_token}"},
     )
     assert res.status_code == 204
-    assert not complaint_obj.allegations.is_connected(a_obj)
+    assert not a_obj.complaint.is_connected(complaint_obj)
 
 
 def test_update_allegation_no_permission(
     client, access_token, example_complaint
 ):
     """Test that a user without edit permissions cannot update an allegation."""
-    a = example_complaint.allegations.single()
+    a = example_complaint.allegations.first()
 
     res = client.patch(
         f"/api/v1/complaints/{example_complaint.uid}/allegations/{a.uid}",
@@ -489,7 +489,7 @@ def test_get_penalties(client, db_session, example_complaint, access_token):
     assert res.status_code == 200
     assert res.json["total"] == len(penalty_objs)
     assert res.json["page"] == 1
-    p = example_complaint.penalties.single()
+    p = example_complaint.penalties.first()
     assert penalties[0]["penalty"] == p.penalty
     assert penalties[0]["date_assessed"] == p.date_assessed.isoformat()
 
@@ -520,7 +520,7 @@ def test_create_penalty(
     # Verify the database is updated
     complaint_obj = Complaint.nodes.get(uid=example_complaint.uid)
     p_obj = Penalty.nodes.get(uid=response["uid"])
-    assert complaint_obj.penalties.is_connected(p_obj)
+    assert p_obj.complaint.is_connected(complaint_obj)
     assert p_obj.penalty == new_penalty["penalty"]
     assert p_obj.date_assessed == date.fromisoformat(
         new_penalty["date_assessed"])
@@ -535,7 +535,7 @@ def test_update_penalty(
         "date_assessed": "2023-01-02"
     }
 
-    p = example_complaint.penalties.single()
+    p = example_complaint.penalties.first()
 
     res = client.patch(
         f"/api/v1/complaints/{example_complaint.uid}/penalties/{p.uid}",
@@ -551,7 +551,7 @@ def test_update_penalty(
 
     # Verify the database is updated
     complaint_obj = Complaint.nodes.get(uid=example_complaint.uid)
-    p_obj = complaint_obj.penalties.single()
+    p_obj = complaint_obj.penalties.first()
     assert p_obj.penalty == updated_data["penalty"]
     assert p_obj.date_assessed == date.fromisoformat(
         updated_data["date_assessed"])
@@ -561,14 +561,14 @@ def test_update_penalty(
         headers={"Authorization": f"Bearer {contributor_access_token}"},
     )
     assert res.status_code == 204
-    assert not complaint_obj.penalties.is_connected(p_obj)
+    assert not p_obj.complaint.is_connected(complaint_obj)
 
 
 def test_update_penalty_no_permission(
     client, access_token, example_complaint
 ):
     """Test that a user without edit permissions cannot update a penalty."""
-    p = example_complaint.penalties.single()
+    p = example_complaint.penalties.first()
 
     res = client.patch(
         f"/api/v1/complaints/{example_complaint.uid}/penalties/{p.uid}",
@@ -600,7 +600,7 @@ def test_get_investigations(
     assert res.status_code == 200
     assert res.json["total"] == len(investigation_objs)
     assert res.json["page"] == 1
-    i = example_complaint.investigations.single()
+    i = example_complaint.investigations.first()
     assert investigations[0]["start_date"] == i.start_date.isoformat()
     assert investigations[0]["end_date"] == i.end_date.isoformat()
 
@@ -631,7 +631,7 @@ def test_create_investigation(
     # Verify the database is updated
     complaint_obj = Complaint.nodes.get(uid=example_complaint.uid)
     i_obj = Investigation.nodes.get(uid=response["uid"])
-    assert complaint_obj.investigations.is_connected(i_obj)
+    assert i_obj.complaint.is_connected(complaint_obj)
     assert i_obj.start_date == date.fromisoformat(
         new_investigation["start_date"])
     assert i_obj.end_date == date.fromisoformat(
@@ -647,7 +647,7 @@ def test_update_investigation(
         "end_date": "2024-12-31"
     }
 
-    i = example_complaint.investigations.single()
+    i = example_complaint.investigations.first()
 
     res = client.patch(
         f"/api/v1/complaints/{example_complaint.uid}/investigations/{i.uid}",
@@ -663,7 +663,7 @@ def test_update_investigation(
 
     # Verify the database is updated
     complaint_obj = Complaint.nodes.get(uid=example_complaint.uid)
-    i_obj = complaint_obj.investigations.single()
+    i_obj = complaint_obj.investigations.first()
     assert i_obj.start_date == date.fromisoformat(updated_data["start_date"])
     assert i_obj.end_date == date.fromisoformat(updated_data["end_date"])
 
@@ -672,7 +672,7 @@ def test_update_investigation(
         headers={"Authorization": f"Bearer {contributor_access_token}"},
     )
     assert res.status_code == 204
-    assert not complaint_obj.investigations.is_connected(i_obj)
+    assert not i_obj.complaint.is_connected(complaint_obj)
 
 
 def test_update_investigation_no_permission(
@@ -680,7 +680,7 @@ def test_update_investigation_no_permission(
 ):
     """Test that a user without edit permissions
     cannot update an investigation."""
-    i = example_complaint.investigations.single()
+    i = example_complaint.investigations.first()
 
     res = client.patch(
         f"/api/v1/complaints/{example_complaint.uid}/investigations/{i.uid}",

--- a/backend/tests/test_complaints.py
+++ b/backend/tests/test_complaints.py
@@ -245,17 +245,17 @@ def test_get_complaint(client, db_session, example_complaint, access_token):
         assert getattr(example_complaint.location.single(), prop) == value
 
     for prop, value in res.json['allegations'][0].items():
-        assert getattr(example_complaint.allegations.single(), prop) == value
+        assert getattr(example_complaint.allegations.first(), prop) == value
 
     for prop, value in res.json['penalties'][0].items():
         if prop == "date_assessed":
             assert getattr(
-                example_complaint.penalties.single(),
+                example_complaint.penalties.first(),
                 prop
             ).isoformat() == value
         else:
             assert getattr(
-                example_complaint.penalties.single(), prop) == value
+                example_complaint.penalties.first(), prop) == value
 
 
 def test_get_complaints(client, db_session, access_token, example_complaints):

--- a/backend/tests/test_officers.py
+++ b/backend/tests/test_officers.py
@@ -537,7 +537,7 @@ def test_get_officers_with_unit(client, db_session, access_token,
 
     results, meta = db.cypher_query("""
         MATCH (o:Officer)
-        MATCH (o)-[:MEMBER_OF_UNIT]->(u:Unit)
+        MATCH (o)-[:MEMBER_OF_UNIT]-(u:Unit)
         where u.name = "Unit Alpha"
         RETURN o
     """)
@@ -561,7 +561,7 @@ def test_get_officers_with_unit_and_agency(client, db_session, access_token,
 
     results, meta = db.cypher_query("""
         MATCH (o:Officer)
-        MATCH (o)-[:MEMBER_OF_UNIT]->(u:Unit)
+        MATCH (o)-[:MEMBER_OF_UNIT]-(u:Unit)
         MATCH (u)-[:ESTABLISHED_BY]-(a:Agency)
         where a.name = "Chicago Police Department"
         RETURN o


### PR DESCRIPTION
Defining relationships from both ends can lead to inconsistencies and confusion. The update leaves only one definition per relationship and creates properties for accessing related nodes more easily from the non-owning side.

The following nodes have been updated:
- Litigation
- Agency
- Unit
- Civilian
- Complaint -- and children
- Officer
- StateID

In cases where there were parent/child relationships, the child nodes have been made the owners of the relationships. This is done because a child node must have a cardinality of `One` or `ZeroOrOne` and this can only be defined on the owning side of a relationship.