### PR TITLE
Fixes an error raised by Agency search results

### DIFF
--- a/backend/routes/search.py
+++ b/backend/routes/search.py
@@ -88,7 +88,7 @@ def create_agency_result(node) -> Searchresult:
         ),
         details=[
             "{} Unit(s) and {} Officers".format(
-                len(a.units) if a.units else 0,
+                a.units.count(),
                 a.total_officers()
             )
         ],

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -323,6 +323,16 @@ class RelQuery:
         cy, params = self._compose(count_only=True)
         rows, _ = db.cypher_query(cy, params)
         return bool(rows and rows[0][0] > 0)
+    
+    def count(self) -> int:
+        """
+        Count the number of nodes matching the query.
+        Returns:
+            int: The count of nodes.
+        """
+        cy, params = self._compose(count_only=True)
+        rows, _ = db.cypher_query(cy, params)
+        return rows[0][0] if rows else 0
 
 
 # Update Enums to work well with NeoModel

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -323,7 +323,7 @@ class RelQuery:
         cy, params = self._compose(count_only=True)
         rows, _ = db.cypher_query(cy, params)
         return bool(rows and rows[0][0] > 0)
-    
+
     def count(self) -> int:
         """
         Count the number of nodes matching the query.

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,14 +1,32 @@
 import urllib.parse
+import pytest
 
-
+@pytest.mark.parametrize(
+    ("query", "expected_content"),
+    [
+        (
+            "john",
+            "Officer",
+        ),
+        (
+            "Example AND Agency",
+            "Agency",
+        )
+    ],
+)
 def test_search_text(
-        client, db_session, example_officer,
-        example_agency, example_unit, access_token):
+        client, db_session, example_officer, example_agency, example_unit,
+        access_token, query, expected_content):
     """Test the search results endpoint."""
-    officer = example_officer
     params = {
-        "query": "john"
+        "query": query,
     }
+    if expected_content == "Officer":
+        uid = example_officer.uid
+        title = example_officer.full_name
+    elif expected_content == "Agency":
+        uid = example_agency.uid
+        title = example_agency.name
 
     query_string = urllib.parse.urlencode(params)
 
@@ -20,9 +38,9 @@ def test_search_text(
     results = data["results"]
     assert isinstance(results, list)
     assert len(results) > 0
-    assert results[0]["uid"] == officer.uid
-    assert results[0]["title"] == officer.full_name
-    assert results[0]["content_type"] == "Officer"
-    assert results[0]["href"] == f"/api/v1/officers/{officer.uid}"
+    assert results[0]["uid"] == uid
+    assert results[0]["title"] == title
+    assert results[0]["content_type"] == expected_content
+    assert results[0]["href"].split("/")[-1] == uid
     assert results[0]["source"] == "Example Source"
     assert "last_updated" in results[0]

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,6 +1,7 @@
 import urllib.parse
 import pytest
 
+
 @pytest.mark.parametrize(
     ("query", "expected_content"),
     [


### PR DESCRIPTION
- The `create_agency_result` function now correctly uses `RelQuery` to count the agency's units.
- Added a count function to `RelQuery`.
- Updated test cases to ensure correct search results for both officers and agencies.